### PR TITLE
Make deployment scripts advertise tenancy

### DIFF
--- a/Solutions/Marain.Tenancy.Deployment/Marain-ArmDeploy.ps1
+++ b/Solutions/Marain.Tenancy.Deployment/Marain-ArmDeploy.ps1
@@ -19,6 +19,5 @@ Function MarainDeployment([MarainServiceDeploymentContext] $ServiceDeploymentCon
         $TemplateParameters,
         $InstanceResourceGroupName)
 
-    #$ServiceDeploymentContext.Variables["KeyVaultName"] = $DeploymentResult.Outputs.keyVaultName.Value
     $ServiceDeploymentContext.SetAppServiceDetails($DeploymentResult.Outputs.functionServicePrincipalId.Value)
 }

--- a/Solutions/Marain.Tenancy.Deployment/Marain-ArmDeploy.ps1
+++ b/Solutions/Marain.Tenancy.Deployment/Marain-ArmDeploy.ps1
@@ -6,9 +6,10 @@ script. It is our opportunity to create Azure resources.
 # Marain.Instance expects us to define just this one function.
 Function MarainDeployment([MarainServiceDeploymentContext] $ServiceDeploymentContext) {
 
+    $TenancyAuthAppId = $ServiceDeploymentContext.GetAppId()
     $TemplateParameters = @{
         appName="tenancy"
-        functionEasyAuthAadClientId=$ServiceDeploymentContext.Variables["TenancyAppId"]
+        functionEasyAuthAadClientId=$TenancyAuthAppId
         appInsightsInstrumentationKey=$ServiceDeploymentContext.InstanceContext.ApplicationInsightsInstrumentationKey
     }
     $InstanceResourceGroupName = $InstanceDeploymentContext.MakeResourceGroupName("tenancy")
@@ -18,6 +19,6 @@ Function MarainDeployment([MarainServiceDeploymentContext] $ServiceDeploymentCon
         $TemplateParameters,
         $InstanceResourceGroupName)
 
-    $ServiceDeploymentContext.Variables["KeyVaultName"] = $DeploymentResult.Outputs.keyVaultName.Value
-    $ServiceDeploymentContext.Variables["FunctionServicePrincipalId"] = $DeploymentResult.Outputs.functionServicePrincipalId.Value
+    #$ServiceDeploymentContext.Variables["KeyVaultName"] = $DeploymentResult.Outputs.keyVaultName.Value
+    $ServiceDeploymentContext.SetAppServiceDetails($DeploymentResult.Outputs.functionServicePrincipalId.Value)
 }

--- a/Solutions/Marain.Tenancy.Deployment/Marain-PostDeploy.ps1
+++ b/Solutions/Marain.Tenancy.Deployment/Marain-PostDeploy.ps1
@@ -7,6 +7,8 @@ have been deployed.
 # Marain.Instance expects us to define just this one function.
 Function MarainDeployment([MarainServiceDeploymentContext] $ServiceDeploymentContext) {
 
+    $ServiceDeploymentContext.MakeAppServiceCommonService("Marain.Tenancy")
+
     $ServiceDeploymentContext.UploadReleaseAssetAsAppServiceSitePackage(
         "Marain.Tenancy.Host.Functions.zip",
         $ServiceDeploymentContext.AppName

--- a/Solutions/Marain.Tenancy.Deployment/Marain-PreDeploy.ps1
+++ b/Solutions/Marain.Tenancy.Deployment/Marain-PreDeploy.ps1
@@ -12,15 +12,21 @@ use it directly.)
 # Marain.Instance expects us to define just this one function.
 Function MarainDeployment([MarainServiceDeploymentContext] $ServiceDeploymentContext) {
 
-    $app = $ServiceDeploymentContext.DefineAzureAdAppForAppService(
-        "",
-         "TenancyAppId")
+    $app = $ServiceDeploymentContext.DefineAzureAdAppForAppService()
 
     $AdminAppRoleId = "7619c293-764c-437b-9a8e-698a26250efd"
     $app.EnsureAppRolesContain(
         $AdminAppRoleId,
         "Tenancy administrator",
-        "Full control over definition of claim permissions and rule sets",
+        "Ability to create, modify, read, and remove tenants",
         "TenancyAdministrator",
+        ("User", "Application"))
+
+    $ReaderAppRoleId = "60743a6a-63b6-42e5-a464-a08698a0e9ed"
+    $app.EnsureAppRolesContain(
+        $ReaderAppRoleId,
+        "Tenancy reader",
+        "Ability to read information about tenants",
+        "TenancyReader",
         ("User", "Application"))
 }


### PR DESCRIPTION
This causes the deployment scripts to declare that tenancy is a common service, enabling other services to obtain details such as the endpoint, and the resource ID to use when authenticating against it, and also to add themselves to its app roles.

Resolves #59 