### PR TITLE
Add basic command line tool for tenant management.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -335,5 +335,6 @@ coverage.cobertura.xml
 # VS Code config files
 .vscode
 local.settings.json
+appsettings.json
 
 **/MsDeploy

--- a/Solutions/Marain.Tenancy.Cli/Marain.Tenancy.Cli.csproj
+++ b/Solutions/Marain.Tenancy.Cli/Marain.Tenancy.Cli.csproj
@@ -1,0 +1,35 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <RootNamespace />
+    <AssemblyName>tenancy</AssemblyName>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Endjin.RecommendedPractices" Version="0.1.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="3.0.0-alpha.268" />
+    <PackageReference Include="McMaster.Extensions.Hosting.CommandLine" Version="3.0.0-alpha.268" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="3.1.2" />
+    <PackageReference Include="Corvus.Identity.ManagedServiceIdentity.ClientAuthentication" Version="0.2.0-preview.5" />
+    <PackageReference Include="ConsoleTables" Version="2.4.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Marain.Tenancy.ClientTenantProvider\Marain.Tenancy.ClientTenantProvider.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update="appsettings.template.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="appsettings.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
+</Project>

--- a/Solutions/Marain.Tenancy.Cli/Marain.Tenancy.Cli.csproj
+++ b/Solutions/Marain.Tenancy.Cli/Marain.Tenancy.Cli.csproj
@@ -26,7 +26,7 @@
 
   <ItemGroup>
     <None Update="appsettings.template.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <CopyToOutputDirectory>Never</CopyToOutputDirectory>
     </None>
     <None Update="appsettings.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>

--- a/Solutions/Marain.Tenancy.Cli/Marain.Tenancy.Cli.csproj
+++ b/Solutions/Marain.Tenancy.Cli/Marain.Tenancy.Cli.csproj
@@ -5,6 +5,7 @@
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <RootNamespace />
     <AssemblyName>tenancy</AssemblyName>
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Solutions/Marain.Tenancy.Cli/Marain.Tenancy.Cli.csproj
+++ b/Solutions/Marain.Tenancy.Cli/Marain.Tenancy.Cli.csproj
@@ -6,6 +6,7 @@
     <RootNamespace />
     <AssemblyName>tenancy</AssemblyName>
     <IsPackable>false</IsPackable>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Solutions/Marain.Tenancy.Cli/Marain/Tenancy/Cli/Commands/Create.cs
+++ b/Solutions/Marain.Tenancy.Cli/Marain/Tenancy/Cli/Commands/Create.cs
@@ -19,7 +19,7 @@ namespace Marain.Tenancy.Cli.Commands
         /// <summary>
         /// Initializes a new instance of the <see cref="Create"/> class.
         /// </summary>
-        /// <param name="tenantProvider">The tenant provider that will be used to retrieve the information.</param>
+        /// <param name="tenantProvider">The tenant provider that will be used to create the new tenant.</param>
         public Create(ITenantProvider tenantProvider)
         {
             this.tenantProvider = tenantProvider;
@@ -28,13 +28,21 @@ namespace Marain.Tenancy.Cli.Commands
         /// <summary>
         /// Gets or sets the tenant whose children should be retrieved.
         /// </summary>
-        [Option(CommandOptionType.SingleOrNoValue, ShortName = "t", LongName = "tenant", Description = "The Id of the parent tenant.")]
+        [Option(
+            CommandOptionType.SingleOrNoValue,
+            ShortName = "t",
+            LongName = "tenant",
+            Description = "The Id of the parent tenant.")]
         public string TenantId { get; set; }
 
         /// <summary>
         /// Gets or sets the tenant whose children should be retrieved.
         /// </summary>
-        [Option(CommandOptionType.SingleValue, ShortName = "n", LongName = "name", Description = "The name of the tenant.")]
+        [Option(
+            CommandOptionType.SingleValue,
+            ShortName = "n",
+            LongName = "name",
+            Description = "The name of the tenant.")]
         public string Name { get; set; }
 
         /// <summary>

--- a/Solutions/Marain.Tenancy.Cli/Marain/Tenancy/Cli/Commands/Create.cs
+++ b/Solutions/Marain.Tenancy.Cli/Marain/Tenancy/Cli/Commands/Create.cs
@@ -36,7 +36,7 @@ namespace Marain.Tenancy.Cli.Commands
             ShortName = "t",
             LongName = "tenant",
             Description = "The Id of the parent tenant. Omit if the child should be a parent of the root tenant.")]
-        public string TenantId { get; set; }
+        public string? TenantId { get; set; }
 
         /// <summary>
         /// Gets or sets the name of the new tenant.
@@ -46,14 +46,14 @@ namespace Marain.Tenancy.Cli.Commands
             ShortName = "n",
             LongName = "name",
             Description = "The name of the new tenant.")]
-        public string Name { get; set; }
+        public string? Name { get; set; }
 
         /// <summary>
         /// Executes the command.
         /// </summary>
         /// <param name="app">The current <c>CommandLineApplication</c>.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<int> OnExecute(CommandLineApplication app)
+        public async Task OnExecute(CommandLineApplication app)
         {
             if (string.IsNullOrEmpty(this.TenantId))
             {
@@ -62,14 +62,9 @@ namespace Marain.Tenancy.Cli.Commands
 
             ITenant child = await this.tenantProvider.CreateChildTenantAsync(this.TenantId).ConfigureAwait(false);
             child.Properties.Set("name", this.Name);
-            await this.tenantProvider.UpdateTenantAsync(child);
+            await this.tenantProvider.UpdateTenantAsync(child).ConfigureAwait(false);
 
-            app.Out.Write("Created new child tenant with Id ");
-            app.Out.Write(child.Id);
-            app.Out.Write(" and name ");
-            app.Out.WriteLine(this.Name);
-
-            return 0;
+            app.Out.WriteLine($"Created new child tenant with Id {child.Id} and name {this.Name}");
         }
     }
 }

--- a/Solutions/Marain.Tenancy.Cli/Marain/Tenancy/Cli/Commands/Create.cs
+++ b/Solutions/Marain.Tenancy.Cli/Marain/Tenancy/Cli/Commands/Create.cs
@@ -26,23 +26,26 @@ namespace Marain.Tenancy.Cli.Commands
         }
 
         /// <summary>
-        /// Gets or sets the tenant whose children should be retrieved.
+        /// Gets or sets the Id of the tenant that should be the parent of the new tenant.
         /// </summary>
+        /// <remarks>
+        /// If ommitted, the tenant will be created at the top level, as a child of the root.
+        /// </remarks>
         [Option(
             CommandOptionType.SingleOrNoValue,
             ShortName = "t",
             LongName = "tenant",
-            Description = "The Id of the parent tenant.")]
+            Description = "The Id of the parent tenant. Omit if the child should be a parent of the root tenant.")]
         public string TenantId { get; set; }
 
         /// <summary>
-        /// Gets or sets the tenant whose children should be retrieved.
+        /// Gets or sets the name of the new tenant.
         /// </summary>
         [Option(
             CommandOptionType.SingleValue,
             ShortName = "n",
             LongName = "name",
-            Description = "The name of the tenant.")]
+            Description = "The name of the new tenant.")]
         public string Name { get; set; }
 
         /// <summary>

--- a/Solutions/Marain.Tenancy.Cli/Marain/Tenancy/Cli/Commands/Create.cs
+++ b/Solutions/Marain.Tenancy.Cli/Marain/Tenancy/Cli/Commands/Create.cs
@@ -1,0 +1,64 @@
+﻿// <copyright file="Create.cs" company="Endjin Limited">
+// Copyright (c) Endjin Limited. All rights reserved.
+// </copyright>
+
+namespace Marain.Tenancy.Cli.Commands
+{
+    using System.Threading.Tasks;
+    using Corvus.Tenancy;
+    using McMaster.Extensions.CommandLineUtils;
+
+    /// <summary>
+    /// Creates a new tenant.
+    /// </summary>
+    [Command(Name = "create", Description = "Create a new tenant.")]
+    public class Create
+    {
+        private readonly ITenantProvider tenantProvider;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Create"/> class.
+        /// </summary>
+        /// <param name="tenantProvider">The tenant provider that will be used to retrieve the information.</param>
+        public Create(ITenantProvider tenantProvider)
+        {
+            this.tenantProvider = tenantProvider;
+        }
+
+        /// <summary>
+        /// Gets or sets the tenant whose children should be retrieved.
+        /// </summary>
+        [Option(CommandOptionType.SingleOrNoValue, ShortName = "t", LongName = "tenant", Description = "The Id of the parent tenant.")]
+        public string TenantId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the tenant whose children should be retrieved.
+        /// </summary>
+        [Option(CommandOptionType.SingleValue, ShortName = "n", LongName = "name", Description = "The name of the tenant.")]
+        public string Name { get; set; }
+
+        /// <summary>
+        /// Executes the command.
+        /// </summary>
+        /// <param name="app">The current <c>CommandLineApplication</c>.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        public async Task<int> OnExecute(CommandLineApplication app)
+        {
+            if (string.IsNullOrEmpty(this.TenantId))
+            {
+                this.TenantId = this.tenantProvider.Root.Id;
+            }
+
+            ITenant child = await this.tenantProvider.CreateChildTenantAsync(this.TenantId).ConfigureAwait(false);
+            child.Properties.Set("name", this.Name);
+            await this.tenantProvider.UpdateTenantAsync(child);
+
+            app.Out.Write("Created new child tenant with Id ");
+            app.Out.Write(child.Id);
+            app.Out.Write(" and name ");
+            app.Out.WriteLine(this.Name);
+
+            return 0;
+        }
+    }
+}

--- a/Solutions/Marain.Tenancy.Cli/Marain/Tenancy/Cli/Commands/Delete.cs
+++ b/Solutions/Marain.Tenancy.Cli/Marain/Tenancy/Cli/Commands/Delete.cs
@@ -28,7 +28,11 @@ namespace Marain.Tenancy.Cli.Commands
         /// <summary>
         /// Gets or sets the tenant whose children should be retrieved.
         /// </summary>
-        [Option(CommandOptionType.SingleValue, ShortName = "t", LongName = "tenant", Description = "The Id of the parent tenant.")]
+        [Option(
+            CommandOptionType.SingleValue,
+            ShortName = "t",
+            LongName = "tenant",
+            Description = "The Id of the parent tenant.")]
         public string TenantId { get; set; }
 
         /// <summary>
@@ -42,7 +46,8 @@ namespace Marain.Tenancy.Cli.Commands
 
             if (children.Tenants.Count > 0)
             {
-                app.Error.WriteLine($"Cannot delete tenant with Id {this.TenantId} as it has children. Remove the child tenants first.");
+                app.Error.WriteLine(
+                    $"Cannot delete tenant with Id {this.TenantId} as it has children. Remove the child tenants first.");
                 return -1;
             }
 

--- a/Solutions/Marain.Tenancy.Cli/Marain/Tenancy/Cli/Commands/Delete.cs
+++ b/Solutions/Marain.Tenancy.Cli/Marain/Tenancy/Cli/Commands/Delete.cs
@@ -1,0 +1,57 @@
+﻿// <copyright file="Delete.cs" company="Endjin Limited">
+// Copyright (c) Endjin Limited. All rights reserved.
+// </copyright>
+
+namespace Marain.Tenancy.Cli.Commands
+{
+    using System.Threading.Tasks;
+    using Corvus.Tenancy;
+    using McMaster.Extensions.CommandLineUtils;
+
+    /// <summary>
+    /// Creates a new tenant.
+    /// </summary>
+    [Command(Name = "delete", Description = "Deletes a tenant.")]
+    public class Delete
+    {
+        private readonly ITenantProvider tenantProvider;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Delete"/> class.
+        /// </summary>
+        /// <param name="tenantProvider">The tenant provider that will be used to retrieve the information.</param>
+        public Delete(ITenantProvider tenantProvider)
+        {
+            this.tenantProvider = tenantProvider;
+        }
+
+        /// <summary>
+        /// Gets or sets the tenant whose children should be retrieved.
+        /// </summary>
+        [Option(CommandOptionType.SingleValue, ShortName = "t", LongName = "tenant", Description = "The Id of the parent tenant.")]
+        public string TenantId { get; set; }
+
+        /// <summary>
+        /// Executes the command.
+        /// </summary>
+        /// <param name="app">The current <c>CommandLineApplication</c>.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        public async Task<int> OnExecute(CommandLineApplication app)
+        {
+            TenantCollectionResult children = await this.tenantProvider.GetChildrenAsync(this.TenantId, 1);
+
+            if (children.Tenants.Count > 0)
+            {
+                app.Error.WriteLine($"Cannot delete tenant with Id {this.TenantId} as it has children. Remove the child tenants first.");
+                return -1;
+            }
+
+            await this.tenantProvider.DeleteTenantAsync(this.TenantId).ConfigureAwait(false);
+
+            app.Out.Write("Deleted tenant with Id ");
+            app.Out.WriteLine(this.TenantId);
+
+            return 0;
+        }
+    }
+}

--- a/Solutions/Marain.Tenancy.Cli/Marain/Tenancy/Cli/Commands/Delete.cs
+++ b/Solutions/Marain.Tenancy.Cli/Marain/Tenancy/Cli/Commands/Delete.cs
@@ -9,7 +9,7 @@ namespace Marain.Tenancy.Cli.Commands
     using McMaster.Extensions.CommandLineUtils;
 
     /// <summary>
-    /// Creates a new tenant.
+    /// Deletes a tenant.
     /// </summary>
     [Command(Name = "delete", Description = "Deletes a tenant.")]
     public class Delete

--- a/Solutions/Marain.Tenancy.Cli/Marain/Tenancy/Cli/Commands/Delete.cs
+++ b/Solutions/Marain.Tenancy.Cli/Marain/Tenancy/Cli/Commands/Delete.cs
@@ -19,14 +19,14 @@ namespace Marain.Tenancy.Cli.Commands
         /// <summary>
         /// Initializes a new instance of the <see cref="Delete"/> class.
         /// </summary>
-        /// <param name="tenantProvider">The tenant provider that will be used to retrieve the information.</param>
+        /// <param name="tenantProvider">The tenant provider that will be used to delete the tenant.</param>
         public Delete(ITenantProvider tenantProvider)
         {
             this.tenantProvider = tenantProvider;
         }
 
         /// <summary>
-        /// Gets or sets the tenant whose children should be retrieved.
+        /// Gets or sets the Id of the tenant to be deleted.
         /// </summary>
         [Option(
             CommandOptionType.SingleValue,

--- a/Solutions/Marain.Tenancy.Cli/Marain/Tenancy/Cli/Commands/Delete.cs
+++ b/Solutions/Marain.Tenancy.Cli/Marain/Tenancy/Cli/Commands/Delete.cs
@@ -33,30 +33,28 @@ namespace Marain.Tenancy.Cli.Commands
             ShortName = "t",
             LongName = "tenant",
             Description = "The Id of the parent tenant.")]
-        public string TenantId { get; set; }
+        public string? TenantId { get; set; }
 
         /// <summary>
         /// Executes the command.
         /// </summary>
         /// <param name="app">The current <c>CommandLineApplication</c>.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<int> OnExecute(CommandLineApplication app)
+        public async Task OnExecute(CommandLineApplication app)
         {
-            TenantCollectionResult children = await this.tenantProvider.GetChildrenAsync(this.TenantId, 1);
+            TenantCollectionResult children = await this.tenantProvider.GetChildrenAsync(this.TenantId, 1).ConfigureAwait(false);
 
             if (children.Tenants.Count > 0)
             {
                 app.Error.WriteLine(
                     $"Cannot delete tenant with Id {this.TenantId} as it has children. Remove the child tenants first.");
-                return -1;
+
+                return;
             }
 
             await this.tenantProvider.DeleteTenantAsync(this.TenantId).ConfigureAwait(false);
 
-            app.Out.Write("Deleted tenant with Id ");
-            app.Out.WriteLine(this.TenantId);
-
-            return 0;
+            app.Out.WriteLine("Deleted tenant with Id " + this.TenantId);
         }
     }
 }

--- a/Solutions/Marain.Tenancy.Cli/Marain/Tenancy/Cli/Commands/Get.cs
+++ b/Solutions/Marain.Tenancy.Cli/Marain/Tenancy/Cli/Commands/Get.cs
@@ -1,0 +1,68 @@
+﻿// <copyright file="Get.cs" company="Endjin Limited">
+// Copyright (c) Endjin Limited. All rights reserved.
+// </copyright>
+
+namespace Marain.Tenancy.Cli.Commands
+{
+    using System;
+    using System.Collections.Generic;
+    using System.IO;
+    using System.Linq;
+    using System.Threading.Tasks;
+    using ConsoleTables;
+    using Corvus.Extensions.Json;
+    using Corvus.Tenancy;
+    using McMaster.Extensions.CommandLineUtils;
+    using Newtonsoft.Json;
+
+    /// <summary>
+    /// Lists children of the specified tenant.
+    /// </summary>
+    [Command(Name = "get", Description = "Gets tenant details.")]
+    public class Get
+    {
+        private readonly ITenantProvider tenantProvider;
+        private readonly IJsonSerializerSettingsProvider serializationSettingsProvider;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Get"/> class.
+        /// </summary>
+        /// <param name="tenantProvider">The tenant provider that will be used to retrieve the information.</param>
+        /// <param name="serializationSettingsProvider">The serialization settings provider to use when writing output.</param>
+        public Get(ITenantProvider tenantProvider, IJsonSerializerSettingsProvider serializationSettingsProvider)
+        {
+            this.tenantProvider = tenantProvider;
+            this.serializationSettingsProvider = serializationSettingsProvider;
+        }
+
+        /// <summary>
+        /// Gets or sets the tenant whose children should be retrieved.
+        /// </summary>
+        [Option(CommandOptionType.SingleValue, ShortName = "t", LongName = "tenant", Description = "The Id of the tenant to retrieve children for. Leave blank to retrieve children of the root tenant.")]
+        public string TenantId { get; set; }
+
+        /// <summary>
+        /// Executes the command.
+        /// </summary>
+        /// <param name="app">The current <c>CommandLineApplication</c>.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        public async Task<int> OnExecute(CommandLineApplication app)
+        {
+            if (string.IsNullOrEmpty(this.TenantId))
+            {
+                this.TenantId = this.tenantProvider.Root.Id;
+            }
+
+            ITenant tenant = await this.tenantProvider.GetTenantAsync(this.TenantId).ConfigureAwait(false);
+
+            string result = JsonConvert.SerializeObject(
+                tenant,
+                Formatting.Indented,
+                this.serializationSettingsProvider.Instance);
+
+            app.Out.WriteLine(result);
+
+            return 0;
+        }
+    }
+}

--- a/Solutions/Marain.Tenancy.Cli/Marain/Tenancy/Cli/Commands/Get.cs
+++ b/Solutions/Marain.Tenancy.Cli/Marain/Tenancy/Cli/Commands/Get.cs
@@ -38,7 +38,11 @@ namespace Marain.Tenancy.Cli.Commands
         /// <summary>
         /// Gets or sets the tenant whose children should be retrieved.
         /// </summary>
-        [Option(CommandOptionType.SingleValue, ShortName = "t", LongName = "tenant", Description = "The Id of the tenant to retrieve children for. Leave blank to retrieve children of the root tenant.")]
+        [Option(
+            CommandOptionType.SingleValue,
+            ShortName = "t",
+            LongName = "tenant",
+            Description = "The Id of the tenant to retrieve children for. Leave blank to retrieve children of the root tenant.")]
         public string TenantId { get; set; }
 
         /// <summary>

--- a/Solutions/Marain.Tenancy.Cli/Marain/Tenancy/Cli/Commands/Get.cs
+++ b/Solutions/Marain.Tenancy.Cli/Marain/Tenancy/Cli/Commands/Get.cs
@@ -38,14 +38,14 @@ namespace Marain.Tenancy.Cli.Commands
             ShortName = "t",
             LongName = "tenant",
             Description = "The Id of the tenant to retrieve details for.")]
-        public string TenantId { get; set; }
+        public string? TenantId { get; set; }
 
         /// <summary>
         /// Executes the command.
         /// </summary>
         /// <param name="app">The current <c>CommandLineApplication</c>.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<int> OnExecute(CommandLineApplication app)
+        public async Task OnExecute(CommandLineApplication app)
         {
             if (string.IsNullOrEmpty(this.TenantId))
             {
@@ -60,8 +60,6 @@ namespace Marain.Tenancy.Cli.Commands
                 this.serializationSettingsProvider.Instance);
 
             app.Out.WriteLine(result);
-
-            return 0;
         }
     }
 }

--- a/Solutions/Marain.Tenancy.Cli/Marain/Tenancy/Cli/Commands/Get.cs
+++ b/Solutions/Marain.Tenancy.Cli/Marain/Tenancy/Cli/Commands/Get.cs
@@ -4,19 +4,14 @@
 
 namespace Marain.Tenancy.Cli.Commands
 {
-    using System;
-    using System.Collections.Generic;
-    using System.IO;
-    using System.Linq;
     using System.Threading.Tasks;
-    using ConsoleTables;
     using Corvus.Extensions.Json;
     using Corvus.Tenancy;
     using McMaster.Extensions.CommandLineUtils;
     using Newtonsoft.Json;
 
     /// <summary>
-    /// Lists children of the specified tenant.
+    /// Retrieves all details for the specified tenant.
     /// </summary>
     [Command(Name = "get", Description = "Gets tenant details.")]
     public class Get
@@ -36,13 +31,13 @@ namespace Marain.Tenancy.Cli.Commands
         }
 
         /// <summary>
-        /// Gets or sets the tenant whose children should be retrieved.
+        /// Gets or sets the tenant whose details should be retrieved.
         /// </summary>
         [Option(
             CommandOptionType.SingleValue,
             ShortName = "t",
             LongName = "tenant",
-            Description = "The Id of the tenant to retrieve children for. Leave blank to retrieve children of the root tenant.")]
+            Description = "The Id of the tenant to retrieve details for.")]
         public string TenantId { get; set; }
 
         /// <summary>

--- a/Solutions/Marain.Tenancy.Cli/Marain/Tenancy/Cli/Commands/List.cs
+++ b/Solutions/Marain.Tenancy.Cli/Marain/Tenancy/Cli/Commands/List.cs
@@ -40,13 +40,13 @@ namespace Marain.Tenancy.Cli.Commands
         public string TenantId { get; set; }
 
         /// <summary>
-        /// Gets or sets a value indicating whether or not details should be loaded for the tenants.
+        /// Gets or sets a value containing the names of specific properties that should be included in the output.
         /// </summary>
         [Option(
             CommandOptionType.MultipleValue,
             ShortName = "p",
             LongName = "property",
-            Description = "The names of properties to include.")]
+            Description = "The names of tenant properties to include in the output. If omitted, only the tenant Ids will be listed.")]
         public string[] IncludeProperties { get; set; }
 
         /// <summary>
@@ -69,7 +69,7 @@ namespace Marain.Tenancy.Cli.Commands
             {
                 TenantCollectionResult children = await this.tenantProvider.GetChildrenAsync(
                     this.TenantId,
-                    2,
+                    20,
                     continuationToken).ConfigureAwait(false);
 
                 childTenantIds.AddRange(children.Tenants);

--- a/Solutions/Marain.Tenancy.Cli/Marain/Tenancy/Cli/Commands/List.cs
+++ b/Solutions/Marain.Tenancy.Cli/Marain/Tenancy/Cli/Commands/List.cs
@@ -4,7 +4,6 @@
 
 namespace Marain.Tenancy.Cli.Commands
 {
-    using System;
     using System.Collections.Generic;
     using System.IO;
     using System.Linq;

--- a/Solutions/Marain.Tenancy.Cli/Marain/Tenancy/Cli/Commands/List.cs
+++ b/Solutions/Marain.Tenancy.Cli/Marain/Tenancy/Cli/Commands/List.cs
@@ -1,0 +1,113 @@
+﻿// <copyright file="List.cs" company="Endjin Limited">
+// Copyright (c) Endjin Limited. All rights reserved.
+// </copyright>
+
+namespace Marain.Tenancy.Cli.Commands
+{
+    using System;
+    using System.Collections.Generic;
+    using System.IO;
+    using System.Linq;
+    using System.Threading.Tasks;
+    using ConsoleTables;
+    using Corvus.Tenancy;
+    using McMaster.Extensions.CommandLineUtils;
+
+    /// <summary>
+    /// Lists children of the specified tenant.
+    /// </summary>
+    [Command(Name = "list", Description = "List tenants.")]
+    public class List
+    {
+        private readonly ITenantProvider tenantProvider;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="List"/> class.
+        /// </summary>
+        /// <param name="tenantProvider">The tenant provider that will be used to retrieve the information.</param>
+        public List(ITenantProvider tenantProvider)
+        {
+            this.tenantProvider = tenantProvider;
+        }
+
+        /// <summary>
+        /// Gets or sets the tenant whose children should be retrieved.
+        /// </summary>
+        [Option(CommandOptionType.SingleOrNoValue, ShortName = "t", LongName = "tenant", Description = "The Id of the tenant to retrieve children for. Leave blank to retrieve children of the root tenant.")]
+        public string TenantId { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether or not details should be loaded for the tenants.
+        /// </summary>
+        [Option(CommandOptionType.MultipleValue, ShortName = "p", LongName = "property", Description = "The names of properties to include.")]
+        public string[] IncludeProperties { get; set; }
+
+        /// <summary>
+        /// Executes the command.
+        /// </summary>
+        /// <param name="app">The current <c>CommandLineApplication</c>.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        public async Task<int> OnExecute(CommandLineApplication app)
+        {
+            if (string.IsNullOrEmpty(this.TenantId))
+            {
+                this.TenantId = this.tenantProvider.Root.Id;
+            }
+
+            TenantCollectionResult children = await this.tenantProvider.GetChildrenAsync(this.TenantId).ConfigureAwait(false);
+
+            if (this.IncludeProperties?.Length > 0)
+            {
+                await this.LoadAndOutputTenantDetailsAsync(children, app.Out).ConfigureAwait(false);
+            }
+            else
+            {
+                this.OutputTenantIds(children, app.Out);
+            }
+
+            return 0;
+        }
+
+        private async Task LoadAndOutputTenantDetailsAsync(TenantCollectionResult children, TextWriter output)
+        {
+            IEnumerable<Task<ITenant>> detailsTasks = children.Tenants.Select(x => this.tenantProvider.GetTenantAsync(x));
+
+            await Task.WhenAll(detailsTasks).ConfigureAwait(false);
+
+            var headings = new List<string> { "Id" };
+            headings.AddRange(this.IncludeProperties);
+
+            var table = new ConsoleTable(headings.ToArray());
+
+            table.Options.OutputTo = output;
+            table.Options.EnableCount = false;
+
+            detailsTasks.ForEach(task =>
+            {
+                ITenant tenant = task.Result;
+
+                var result = new List<string> { tenant.Id };
+
+                foreach (string prop in this.IncludeProperties)
+                {
+                    tenant.Properties.TryGet<string>(prop, out string propValue);
+                    result.Add(propValue ?? "{not set}");
+                }
+
+                table.AddRow(result.ToArray());
+            });
+
+            table.Write(Format.Minimal);
+        }
+
+        private void OutputTenantIds(TenantCollectionResult children, TextWriter output)
+        {
+            output.WriteLine("Child Tenant Ids:");
+
+            foreach (string current in children.Tenants)
+            {
+                output.WriteLine($"\t{current}");
+            }
+        }
+    }
+}

--- a/Solutions/Marain.Tenancy.Cli/Marain/Tenancy/Cli/Commands/List.cs
+++ b/Solutions/Marain.Tenancy.Cli/Marain/Tenancy/Cli/Commands/List.cs
@@ -33,13 +33,21 @@ namespace Marain.Tenancy.Cli.Commands
         /// <summary>
         /// Gets or sets the tenant whose children should be retrieved.
         /// </summary>
-        [Option(CommandOptionType.SingleOrNoValue, ShortName = "t", LongName = "tenant", Description = "The Id of the tenant to retrieve children for. Leave blank to retrieve children of the root tenant.")]
+        [Option(
+            CommandOptionType.SingleOrNoValue,
+            ShortName = "t",
+            LongName = "tenant",
+            Description = "The Id of the tenant to retrieve children for. Leave blank to retrieve children of the root tenant.")]
         public string TenantId { get; set; }
 
         /// <summary>
         /// Gets or sets a value indicating whether or not details should be loaded for the tenants.
         /// </summary>
-        [Option(CommandOptionType.MultipleValue, ShortName = "p", LongName = "property", Description = "The names of properties to include.")]
+        [Option(
+            CommandOptionType.MultipleValue,
+            ShortName = "p",
+            LongName = "property",
+            Description = "The names of properties to include.")]
         public string[] IncludeProperties { get; set; }
 
         /// <summary>
@@ -60,7 +68,10 @@ namespace Marain.Tenancy.Cli.Commands
 
             do
             {
-                TenantCollectionResult children = await this.tenantProvider.GetChildrenAsync(this.TenantId, 2, continuationToken).ConfigureAwait(false);
+                TenantCollectionResult children = await this.tenantProvider.GetChildrenAsync(
+                    this.TenantId,
+                    2,
+                    continuationToken).ConfigureAwait(false);
 
                 childTenantIds.AddRange(children.Tenants);
 

--- a/Solutions/Marain.Tenancy.Cli/Marain/Tenancy/Cli/Commands/List.cs
+++ b/Solutions/Marain.Tenancy.Cli/Marain/Tenancy/Cli/Commands/List.cs
@@ -109,7 +109,7 @@ namespace Marain.Tenancy.Cli.Commands
             table.Options.OutputTo = output;
             table.Options.EnableCount = false;
 
-            tenants.ForEach(tenant =>
+            foreach (ITenant tenant in tenants)
             {
                 var result = new List<string> { tenant.Id };
 
@@ -123,7 +123,7 @@ namespace Marain.Tenancy.Cli.Commands
                 }
 
                 table.AddRow(result.ToArray());
-            });
+            }
 
             table.Write(Format.Minimal);
         }

--- a/Solutions/Marain.Tenancy.Cli/Marain/Tenancy/Cli/Commands/List.cs
+++ b/Solutions/Marain.Tenancy.Cli/Marain/Tenancy/Cli/Commands/List.cs
@@ -95,7 +95,7 @@ namespace Marain.Tenancy.Cli.Commands
         {
             IEnumerable<Task<ITenant>> detailsTasks = children.Select(x => this.tenantProvider.GetTenantAsync(x));
 
-            await Task.WhenAll(detailsTasks).ConfigureAwait(false);
+            ITenant[] tenants = await Task.WhenAll(detailsTasks).ConfigureAwait(false);
 
             var headings = new List<string> { "Id" };
 
@@ -109,10 +109,8 @@ namespace Marain.Tenancy.Cli.Commands
             table.Options.OutputTo = output;
             table.Options.EnableCount = false;
 
-            detailsTasks.ForEach(task =>
+            tenants.ForEach(tenant =>
             {
-                ITenant tenant = task.Result;
-
                 var result = new List<string> { tenant.Id };
 
                 if (this.IncludeProperties != null)

--- a/Solutions/Marain.Tenancy.Cli/Marain/Tenancy/Cli/Program.cs
+++ b/Solutions/Marain.Tenancy.Cli/Marain/Tenancy/Cli/Program.cs
@@ -29,6 +29,8 @@ namespace Marain.Tenancy.Cli
 
             builder.ConfigureServices((ctx, services) =>
             {
+                services.AddJsonSerializerSettings();
+
                 var msiTokenSourceOptions = new AzureManagedIdentityTokenSourceOptions
                 {
                     AzureServicesAuthConnectionString = ctx.Configuration["AzureServicesAuthConnectionString"],
@@ -43,6 +45,7 @@ namespace Marain.Tenancy.Cli
                 };
 
                 services.AddSingleton(tenancyClientOptions);
+
                 services.AddTenantProviderServiceClient();
             });
 

--- a/Solutions/Marain.Tenancy.Cli/Marain/Tenancy/Cli/Program.cs
+++ b/Solutions/Marain.Tenancy.Cli/Marain/Tenancy/Cli/Program.cs
@@ -1,0 +1,52 @@
+﻿// <copyright file="Program.cs" company="Endjin Limited">
+// Copyright (c) Endjin Limited. All rights reserved.
+// </copyright>
+
+namespace Marain.Tenancy.Cli
+{
+    using System;
+    using System.Threading.Tasks;
+    using Corvus.Identity.ManagedServiceIdentity.ClientAuthentication;
+    using Marain.Tenancy.Cli.Commands;
+    using Marain.Tenancy.Client;
+    using Microsoft.Extensions.Configuration;
+    using Microsoft.Extensions.DependencyInjection;
+    using Microsoft.Extensions.Hosting;
+
+    /// <summary>
+    /// The entry point for the application. Configures the commands.
+    /// </summary>
+    public static class Program
+    {
+        /// <summary>
+        /// The entry point method.
+        /// </summary>
+        /// <param name="args">The arguments.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        public static async Task Main(string[] args)
+        {
+            IHostBuilder builder = Host.CreateDefaultBuilder();
+
+            builder.ConfigureServices((ctx, services) =>
+            {
+                var msiTokenSourceOptions = new AzureManagedIdentityTokenSourceOptions
+                {
+                    AzureServicesAuthConnectionString = ctx.Configuration["AzureServicesAuthConnectionString"],
+                };
+
+                services.AddAzureManagedIdentityBasedTokenSource(msiTokenSourceOptions);
+
+                var tenancyClientOptions = new TenancyClientOptions
+                {
+                    TenancyServiceBaseUri = new Uri(ctx.Configuration["TenancyClient:TenancyServiceBaseUri"]),
+                    ResourceIdForMsiAuthentication = ctx.Configuration["TenancyClient:ResourceIdForMsiAuthentication"],
+                };
+
+                services.AddSingleton(tenancyClientOptions);
+                services.AddTenantProviderServiceClient();
+            });
+
+            await builder.RunCommandLineApplicationAsync<TenancyCliCommand>(args).ConfigureAwait(false);
+        }
+    }
+}

--- a/Solutions/Marain.Tenancy.Cli/Marain/Tenancy/Cli/Program.cs
+++ b/Solutions/Marain.Tenancy.Cli/Marain/Tenancy/Cli/Program.cs
@@ -7,9 +7,7 @@ namespace Marain.Tenancy.Cli
     using System;
     using System.Threading.Tasks;
     using Corvus.Identity.ManagedServiceIdentity.ClientAuthentication;
-    using Marain.Tenancy.Cli.Commands;
     using Marain.Tenancy.Client;
-    using Microsoft.Extensions.Configuration;
     using Microsoft.Extensions.DependencyInjection;
     using Microsoft.Extensions.Hosting;
 

--- a/Solutions/Marain.Tenancy.Cli/Marain/Tenancy/Cli/TenancyCliCommand.cs
+++ b/Solutions/Marain.Tenancy.Cli/Marain/Tenancy/Cli/TenancyCliCommand.cs
@@ -1,0 +1,31 @@
+﻿// <copyright file="TenancyCliCommand.cs" company="Endjin Limited">
+// Copyright (c) Endjin Limited. All rights reserved.
+// </copyright>
+
+namespace Marain.Tenancy.Cli
+{
+    using System.Threading.Tasks;
+    using Marain.Tenancy.Cli.Commands;
+    using McMaster.Extensions.CommandLineUtils;
+
+    /// <summary>
+    /// Base class for CLI command implementations.
+    /// </summary>
+    [Command(Name = "tenancy")]
+    [Subcommand(typeof(List))]
+    [Subcommand(typeof(Create))]
+    [Subcommand(typeof(Delete))]
+    public class TenancyCliCommand
+    {
+        /// <summary>
+        /// Executes the command.
+        /// </summary>
+        /// <param name="app">The current <c>CommandLineApplication</c>.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        protected Task<int> OnExecute(CommandLineApplication app)
+        {
+            app.ShowHelp();
+            return Task.FromResult(0);
+        }
+    }
+}

--- a/Solutions/Marain.Tenancy.Cli/Marain/Tenancy/Cli/TenancyCliCommand.cs
+++ b/Solutions/Marain.Tenancy.Cli/Marain/Tenancy/Cli/TenancyCliCommand.cs
@@ -15,6 +15,7 @@ namespace Marain.Tenancy.Cli
     [Subcommand(typeof(List))]
     [Subcommand(typeof(Create))]
     [Subcommand(typeof(Delete))]
+    [Subcommand(typeof(DeleteProperty))]
     [Subcommand(typeof(Get))]
     public class TenancyCliCommand
     {

--- a/Solutions/Marain.Tenancy.Cli/Marain/Tenancy/Cli/TenancyCliCommand.cs
+++ b/Solutions/Marain.Tenancy.Cli/Marain/Tenancy/Cli/TenancyCliCommand.cs
@@ -15,6 +15,7 @@ namespace Marain.Tenancy.Cli
     [Subcommand(typeof(List))]
     [Subcommand(typeof(Create))]
     [Subcommand(typeof(Delete))]
+    [Subcommand(typeof(Get))]
     public class TenancyCliCommand
     {
         /// <summary>

--- a/Solutions/Marain.Tenancy.Cli/Marain/Tenancy/Cli/TenancyCliCommand.cs
+++ b/Solutions/Marain.Tenancy.Cli/Marain/Tenancy/Cli/TenancyCliCommand.cs
@@ -15,7 +15,6 @@ namespace Marain.Tenancy.Cli
     [Subcommand(typeof(List))]
     [Subcommand(typeof(Create))]
     [Subcommand(typeof(Delete))]
-    [Subcommand(typeof(DeleteProperty))]
     [Subcommand(typeof(Get))]
     public class TenancyCliCommand
     {

--- a/Solutions/Marain.Tenancy.Cli/appsettings.template.json
+++ b/Solutions/Marain.Tenancy.Cli/appsettings.template.json
@@ -1,0 +1,16 @@
+﻿{
+  // If running with a local tenancy service, point TenancyClient:TenancyServiceBaseUri at the localhost address for that
+  // and set the ResourceIdForMsiAuthentication to an empty string.
+  "TenancyClient:TenancyServiceBaseUri": "https://mardevtenancy.azurewebsites.net/",
+  "TenancyClient:ResourceIdForMsiAuthentication": "f1815180-9920-477b-95cc-7b93c2cd5de0"
+
+  // If TenancyClient:TenancyServiceBaseUri refers to an instance in Azure, or if you've configured
+  // TenantCosmosContainerFactoryOptions, this local service will need to authenticate.
+  // And for that to work, you won't be able to use the normal az cli-based AzureServicesAuthConnectionString
+  // (because az cli is only able to obtain tokens for a fixed set of known Microsoft resource; it can't be
+  // used to obtain tokens for arbitrary applications that we've defined). Instead, you'll need to create
+  // a suitable service principle in AAD, grant that service principle access to the tenancy service, and
+  // set up the credentials like this instead of the setting above:
+  //  "AzureServicesAuthConnectionString": "RunAs=App;AppId=AppIdForYourServicePrinciple;TenantId=0f621c67-98a0-4ed5-b5bd-31a35be41e29;AppKey=YourAppSecretHere"
+
+}

--- a/Solutions/Marain.Tenancy.ClientTenantProvider/Marain/Tenancy/ClientTenantProvider.cs
+++ b/Solutions/Marain.Tenancy.ClientTenantProvider/Marain/Tenancy/ClientTenantProvider.cs
@@ -112,7 +112,27 @@ namespace Marain.Tenancy
             }
 
             var haldoc = (JObject)result.Body;
-            IEnumerable<string> tenantIds = haldoc["_links"]["getTenant"].Cast<JObject>().Select(link => this.tenantMapper.ExtractTenantIdFrom(this.tenantService.BaseUri, (string)link["href"]));
+
+            JToken getTenantLinks = haldoc["_links"]["getTenant"];
+
+            IEnumerable<string> tenantIds;
+
+            if (getTenantLinks == null)
+            {
+                tenantIds = new string[0];
+            }
+            else if (getTenantLinks is JArray)
+            {
+                tenantIds = getTenantLinks.Cast<JObject>().Select(link => this.tenantMapper.ExtractTenantIdFrom(this.tenantService.BaseUri, (string)link["href"]));
+            }
+            else
+            {
+                tenantIds = new string[]
+                {
+                    this.tenantMapper.ExtractTenantIdFrom(this.tenantService.BaseUri, (string)getTenantLinks["href"]),
+                };
+            }
+
             string ct = this.tenantMapper.ExtractContinationTokenFrom(this.tenantService.BaseUri, (string)haldoc.SelectToken("_links.next.href"));
             return new TenantCollectionResult(tenantIds.ToList(), ct);
         }

--- a/Solutions/Marain.Tenancy.Specs/Integration/Features/TenancyClient.feature
+++ b/Solutions/Marain.Tenancy.Specs/Integration/Features/TenancyClient.feature
@@ -71,6 +71,21 @@ Scenario: Get children
 	| ChildTenant4 |
 	| ChildTenant5 |
 
+Scenario: Get children when no child tenants exist
+	Given I create a child tenant called "ChildTenant1" for the root tenant
+	When I get the tenant id of the tenant called "ChildTenant1" and call it "ChildTenantId"
+	And I get the children of the tenant with the id called "ChildTenantId" with maxItems 20 and call them "Result"
+	Then there should be no ids in the children called "Result"
+
+Scenario: Get children when there is a single child tenant
+	Given I create a child tenant called "ChildTenant1" for the root tenant
+	And I create a child tenant called "ChildTenant2" for the tenant called "ChildTenant1"
+	When I get the tenant id of the tenant called "ChildTenant1" and call it "ChildTenantId"
+	And I get the children of the tenant with the id called "ChildTenantId" with maxItems 20 and call them "Result"
+	Then the ids of the children called "Result" should match the ids of the tenants called
+	| TenantName   |
+	| ChildTenant2 |
+
 Scenario: Get children with continuation token
 	Given I create a child tenant called "ChildTenant1" for the root tenant
 	And I create a child tenant called "ChildTenant2" for the tenant called "ChildTenant1"

--- a/Solutions/Marain.Tenancy.Specs/Integration/Features/TenancyClient.feature.cs
+++ b/Solutions/Marain.Tenancy.Specs/Integration/Features/TenancyClient.feature.cs
@@ -462,11 +462,11 @@ this.ScenarioInitialize(scenarioInfo);
         }
         
         [NUnit.Framework.TestAttribute()]
-        [NUnit.Framework.DescriptionAttribute("Get children with continuation token")]
-        public virtual void GetChildrenWithContinuationToken()
+        [NUnit.Framework.DescriptionAttribute("Get children when no child tenants exist")]
+        public virtual void GetChildrenWhenNoChildTenantsExist()
         {
             string[] tagsOfScenario = ((string[])(null));
-            TechTalk.SpecFlow.ScenarioInfo scenarioInfo = new TechTalk.SpecFlow.ScenarioInfo("Get children with continuation token", null, ((string[])(null)));
+            TechTalk.SpecFlow.ScenarioInfo scenarioInfo = new TechTalk.SpecFlow.ScenarioInfo("Get children when no child tenants exist", null, ((string[])(null)));
 #line 74
 this.ScenarioInitialize(scenarioInfo);
 #line hidden
@@ -491,64 +491,27 @@ this.ScenarioInitialize(scenarioInfo);
  testRunner.Given("I create a child tenant called \"ChildTenant1\" for the root tenant", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Given ");
 #line hidden
 #line 76
- testRunner.And("I create a child tenant called \"ChildTenant2\" for the tenant called \"ChildTenant1" +
-                        "\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
-#line hidden
-#line 77
- testRunner.And("I create a child tenant called \"ChildTenant3\" for the tenant called \"ChildTenant1" +
-                        "\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
-#line hidden
-#line 78
- testRunner.And("I create a child tenant called \"ChildTenant4\" for the tenant called \"ChildTenant1" +
-                        "\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
-#line hidden
-#line 79
- testRunner.And("I create a child tenant called \"ChildTenant5\" for the tenant called \"ChildTenant1" +
-                        "\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
-#line hidden
-#line 80
  testRunner.When("I get the tenant id of the tenant called \"ChildTenant1\" and call it \"ChildTenantI" +
                         "d\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
 #line hidden
-#line 81
+#line 77
  testRunner.And("I get the children of the tenant with the id called \"ChildTenantId\" with maxItems" +
-                        " 2 and call them \"Result\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+                        " 20 and call them \"Result\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
 #line hidden
-#line 82
- testRunner.And("I get the children of the tenant with the id called \"ChildTenantId\" with maxItems" +
-                        " 20 and continuation token \"Result\" and call them \"Result2\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
-#line hidden
-#line 83
- testRunner.Then("there should be 2 tenants in \"Result\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
-#line hidden
-#line 84
- testRunner.And("there should be 2 tenants in \"Result2\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
-#line hidden
-                TechTalk.SpecFlow.Table table4 = new TechTalk.SpecFlow.Table(new string[] {
-                            "TenantName"});
-                table4.AddRow(new string[] {
-                            "ChildTenant5"});
-                table4.AddRow(new string[] {
-                            "ChildTenant4"});
-                table4.AddRow(new string[] {
-                            "ChildTenant3"});
-                table4.AddRow(new string[] {
-                            "ChildTenant2"});
-#line 85
- testRunner.And("the ids of the children called \"Result\" and \"Result2\" should each match 2 of the " +
-                        "ids of the tenants called", ((string)(null)), table4, "And ");
+#line 78
+ testRunner.Then("there should be no ids in the children called \"Result\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
 #line hidden
             }
             this.ScenarioCleanup();
         }
         
         [NUnit.Framework.TestAttribute()]
-        [NUnit.Framework.DescriptionAttribute("Delete a child")]
-        public virtual void DeleteAChild()
+        [NUnit.Framework.DescriptionAttribute("Get children when there is a single child tenant")]
+        public virtual void GetChildrenWhenThereIsASingleChildTenant()
         {
             string[] tagsOfScenario = ((string[])(null));
-            TechTalk.SpecFlow.ScenarioInfo scenarioInfo = new TechTalk.SpecFlow.ScenarioInfo("Delete a child", null, ((string[])(null)));
-#line 92
+            TechTalk.SpecFlow.ScenarioInfo scenarioInfo = new TechTalk.SpecFlow.ScenarioInfo("Get children when there is a single child tenant", null, ((string[])(null)));
+#line 80
 this.ScenarioInitialize(scenarioInfo);
 #line hidden
             bool isScenarioIgnored = default(bool);
@@ -568,51 +531,185 @@ this.ScenarioInitialize(scenarioInfo);
             else
             {
                 this.ScenarioStart();
-#line 93
+#line 81
  testRunner.Given("I create a child tenant called \"ChildTenant1\" for the root tenant", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Given ");
 #line hidden
-#line 94
+#line 82
  testRunner.And("I create a child tenant called \"ChildTenant2\" for the tenant called \"ChildTenant1" +
                         "\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
 #line hidden
-#line 95
- testRunner.And("I create a child tenant called \"ChildTenant3\" for the tenant called \"ChildTenant1" +
-                        "\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
-#line hidden
-#line 96
- testRunner.And("I create a child tenant called \"ChildTenant4\" for the tenant called \"ChildTenant1" +
-                        "\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
-#line hidden
-#line 97
- testRunner.And("I create a child tenant called \"ChildTenant5\" for the tenant called \"ChildTenant1" +
-                        "\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
-#line hidden
-#line 98
+#line 83
  testRunner.When("I get the tenant id of the tenant called \"ChildTenant1\" and call it \"ChildTenantI" +
                         "d\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
 #line hidden
-#line 99
- testRunner.And("I get the tenant id of the tenant called \"ChildTenant3\" and call it \"DeletedChild" +
-                        "TenantId\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
-#line hidden
-#line 100
- testRunner.And("I delete the tenant with the id called \"DeletedChildTenantId\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
-#line hidden
-#line 101
+#line 84
  testRunner.And("I get the children of the tenant with the id called \"ChildTenantId\" with maxItems" +
                         " 20 and call them \"Result\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line hidden
+                TechTalk.SpecFlow.Table table4 = new TechTalk.SpecFlow.Table(new string[] {
+                            "TenantName"});
+                table4.AddRow(new string[] {
+                            "ChildTenant2"});
+#line 85
+ testRunner.Then("the ids of the children called \"Result\" should match the ids of the tenants calle" +
+                        "d", ((string)(null)), table4, "Then ");
+#line hidden
+            }
+            this.ScenarioCleanup();
+        }
+        
+        [NUnit.Framework.TestAttribute()]
+        [NUnit.Framework.DescriptionAttribute("Get children with continuation token")]
+        public virtual void GetChildrenWithContinuationToken()
+        {
+            string[] tagsOfScenario = ((string[])(null));
+            TechTalk.SpecFlow.ScenarioInfo scenarioInfo = new TechTalk.SpecFlow.ScenarioInfo("Get children with continuation token", null, ((string[])(null)));
+#line 89
+this.ScenarioInitialize(scenarioInfo);
+#line hidden
+            bool isScenarioIgnored = default(bool);
+            bool isFeatureIgnored = default(bool);
+            if ((tagsOfScenario != null))
+            {
+                isScenarioIgnored = tagsOfScenario.Where(__entry => __entry != null).Where(__entry => String.Equals(__entry, "ignore", StringComparison.CurrentCultureIgnoreCase)).Any();
+            }
+            if ((this._featureTags != null))
+            {
+                isFeatureIgnored = this._featureTags.Where(__entry => __entry != null).Where(__entry => String.Equals(__entry, "ignore", StringComparison.CurrentCultureIgnoreCase)).Any();
+            }
+            if ((isScenarioIgnored || isFeatureIgnored))
+            {
+                testRunner.SkipScenario();
+            }
+            else
+            {
+                this.ScenarioStart();
+#line 90
+ testRunner.Given("I create a child tenant called \"ChildTenant1\" for the root tenant", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Given ");
+#line hidden
+#line 91
+ testRunner.And("I create a child tenant called \"ChildTenant2\" for the tenant called \"ChildTenant1" +
+                        "\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line hidden
+#line 92
+ testRunner.And("I create a child tenant called \"ChildTenant3\" for the tenant called \"ChildTenant1" +
+                        "\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line hidden
+#line 93
+ testRunner.And("I create a child tenant called \"ChildTenant4\" for the tenant called \"ChildTenant1" +
+                        "\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line hidden
+#line 94
+ testRunner.And("I create a child tenant called \"ChildTenant5\" for the tenant called \"ChildTenant1" +
+                        "\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line hidden
+#line 95
+ testRunner.When("I get the tenant id of the tenant called \"ChildTenant1\" and call it \"ChildTenantI" +
+                        "d\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
+#line hidden
+#line 96
+ testRunner.And("I get the children of the tenant with the id called \"ChildTenantId\" with maxItems" +
+                        " 2 and call them \"Result\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line hidden
+#line 97
+ testRunner.And("I get the children of the tenant with the id called \"ChildTenantId\" with maxItems" +
+                        " 20 and continuation token \"Result\" and call them \"Result2\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line hidden
+#line 98
+ testRunner.Then("there should be 2 tenants in \"Result\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
+#line hidden
+#line 99
+ testRunner.And("there should be 2 tenants in \"Result2\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
 #line hidden
                 TechTalk.SpecFlow.Table table5 = new TechTalk.SpecFlow.Table(new string[] {
                             "TenantName"});
                 table5.AddRow(new string[] {
-                            "ChildTenant2"});
+                            "ChildTenant5"});
                 table5.AddRow(new string[] {
                             "ChildTenant4"});
                 table5.AddRow(new string[] {
+                            "ChildTenant3"});
+                table5.AddRow(new string[] {
+                            "ChildTenant2"});
+#line 100
+ testRunner.And("the ids of the children called \"Result\" and \"Result2\" should each match 2 of the " +
+                        "ids of the tenants called", ((string)(null)), table5, "And ");
+#line hidden
+            }
+            this.ScenarioCleanup();
+        }
+        
+        [NUnit.Framework.TestAttribute()]
+        [NUnit.Framework.DescriptionAttribute("Delete a child")]
+        public virtual void DeleteAChild()
+        {
+            string[] tagsOfScenario = ((string[])(null));
+            TechTalk.SpecFlow.ScenarioInfo scenarioInfo = new TechTalk.SpecFlow.ScenarioInfo("Delete a child", null, ((string[])(null)));
+#line 107
+this.ScenarioInitialize(scenarioInfo);
+#line hidden
+            bool isScenarioIgnored = default(bool);
+            bool isFeatureIgnored = default(bool);
+            if ((tagsOfScenario != null))
+            {
+                isScenarioIgnored = tagsOfScenario.Where(__entry => __entry != null).Where(__entry => String.Equals(__entry, "ignore", StringComparison.CurrentCultureIgnoreCase)).Any();
+            }
+            if ((this._featureTags != null))
+            {
+                isFeatureIgnored = this._featureTags.Where(__entry => __entry != null).Where(__entry => String.Equals(__entry, "ignore", StringComparison.CurrentCultureIgnoreCase)).Any();
+            }
+            if ((isScenarioIgnored || isFeatureIgnored))
+            {
+                testRunner.SkipScenario();
+            }
+            else
+            {
+                this.ScenarioStart();
+#line 108
+ testRunner.Given("I create a child tenant called \"ChildTenant1\" for the root tenant", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Given ");
+#line hidden
+#line 109
+ testRunner.And("I create a child tenant called \"ChildTenant2\" for the tenant called \"ChildTenant1" +
+                        "\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line hidden
+#line 110
+ testRunner.And("I create a child tenant called \"ChildTenant3\" for the tenant called \"ChildTenant1" +
+                        "\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line hidden
+#line 111
+ testRunner.And("I create a child tenant called \"ChildTenant4\" for the tenant called \"ChildTenant1" +
+                        "\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line hidden
+#line 112
+ testRunner.And("I create a child tenant called \"ChildTenant5\" for the tenant called \"ChildTenant1" +
+                        "\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line hidden
+#line 113
+ testRunner.When("I get the tenant id of the tenant called \"ChildTenant1\" and call it \"ChildTenantI" +
+                        "d\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
+#line hidden
+#line 114
+ testRunner.And("I get the tenant id of the tenant called \"ChildTenant3\" and call it \"DeletedChild" +
+                        "TenantId\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line hidden
+#line 115
+ testRunner.And("I delete the tenant with the id called \"DeletedChildTenantId\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line hidden
+#line 116
+ testRunner.And("I get the children of the tenant with the id called \"ChildTenantId\" with maxItems" +
+                        " 20 and call them \"Result\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line hidden
+                TechTalk.SpecFlow.Table table6 = new TechTalk.SpecFlow.Table(new string[] {
+                            "TenantName"});
+                table6.AddRow(new string[] {
+                            "ChildTenant2"});
+                table6.AddRow(new string[] {
+                            "ChildTenant4"});
+                table6.AddRow(new string[] {
                             "ChildTenant5"});
-#line 102
+#line 117
  testRunner.Then("the ids of the children called \"Result\" should match the ids of the tenants calle" +
-                        "d", ((string)(null)), table5, "Then ");
+                        "d", ((string)(null)), table6, "Then ");
 #line hidden
             }
             this.ScenarioCleanup();
@@ -622,15 +719,35 @@ this.ScenarioInitialize(scenarioInfo);
         [NUnit.Framework.DescriptionAttribute("Root tenant has empty properties")]
         public virtual void RootTenantHasEmptyProperties()
         {
+            string[] tagsOfScenario = ((string[])(null));
             TechTalk.SpecFlow.ScenarioInfo scenarioInfo = new TechTalk.SpecFlow.ScenarioInfo("Root tenant has empty properties", null, ((string[])(null)));
-#line 108
+#line 123
 this.ScenarioInitialize(scenarioInfo);
-            this.ScenarioStart();
-#line 109
+#line hidden
+            bool isScenarioIgnored = default(bool);
+            bool isFeatureIgnored = default(bool);
+            if ((tagsOfScenario != null))
+            {
+                isScenarioIgnored = tagsOfScenario.Where(__entry => __entry != null).Where(__entry => String.Equals(__entry, "ignore", StringComparison.CurrentCultureIgnoreCase)).Any();
+            }
+            if ((this._featureTags != null))
+            {
+                isFeatureIgnored = this._featureTags.Where(__entry => __entry != null).Where(__entry => String.Equals(__entry, "ignore", StringComparison.CurrentCultureIgnoreCase)).Any();
+            }
+            if ((isScenarioIgnored || isFeatureIgnored))
+            {
+                testRunner.SkipScenario();
+            }
+            else
+            {
+                this.ScenarioStart();
+#line 124
  testRunner.When("I get the tenant with id \"f26450ab1668784bb327951c8b08f347\" and call it \"Root\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
-#line 110
+#line hidden
+#line 125
  testRunner.Then("the tenant called \"Root\" should have no properties", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
 #line hidden
+            }
             this.ScenarioCleanup();
         }
         
@@ -638,16 +755,36 @@ this.ScenarioInitialize(scenarioInfo);
         [NUnit.Framework.DescriptionAttribute("Updates to root tenant are prohibited")]
         public virtual void UpdatesToRootTenantAreProhibited()
         {
+            string[] tagsOfScenario = ((string[])(null));
             TechTalk.SpecFlow.ScenarioInfo scenarioInfo = new TechTalk.SpecFlow.ScenarioInfo("Updates to root tenant are prohibited", null, ((string[])(null)));
-#line 112
+#line 127
 this.ScenarioInitialize(scenarioInfo);
-            this.ScenarioStart();
-#line 113
+#line hidden
+            bool isScenarioIgnored = default(bool);
+            bool isFeatureIgnored = default(bool);
+            if ((tagsOfScenario != null))
+            {
+                isScenarioIgnored = tagsOfScenario.Where(__entry => __entry != null).Where(__entry => String.Equals(__entry, "ignore", StringComparison.CurrentCultureIgnoreCase)).Any();
+            }
+            if ((this._featureTags != null))
+            {
+                isFeatureIgnored = this._featureTags.Where(__entry => __entry != null).Where(__entry => String.Equals(__entry, "ignore", StringComparison.CurrentCultureIgnoreCase)).Any();
+            }
+            if ((isScenarioIgnored || isFeatureIgnored))
+            {
+                testRunner.SkipScenario();
+            }
+            else
+            {
+                this.ScenarioStart();
+#line 128
  testRunner.When("I try to update the properties of the tenant with id \"f26450ab1668784bb327951c8b0" +
-                    "8f347\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
-#line 114
+                        "8f347\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
+#line hidden
+#line 129
  testRunner.Then("it should throw a NotSupportedException", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
 #line hidden
+            }
             this.ScenarioCleanup();
         }
     }

--- a/Solutions/Marain.Tenancy.Specs/Integration/Steps/TenancyClientSteps.cs
+++ b/Solutions/Marain.Tenancy.Specs/Integration/Steps/TenancyClientSteps.cs
@@ -205,6 +205,13 @@
             CollectionAssert.AreEquivalent(expected, children.Tenants);
         }
 
+        [Then("there should be no ids in the children called \"(.*)\"")]
+        public void ThenThereShouldBeNoIdsInTheChildrenCalled(string childrenName)
+        {
+            TenantCollectionResult children = this.scenarioContext.Get<TenantCollectionResult>(childrenName);
+            Assert.AreEqual(0, children.Tenants.Count);
+        }
+
         [Then("there should be (.*) tenants in \"(.*)\"")]
         public void ThenThereShouldBeTenantsIn(int count, string childrenName)
         {

--- a/Solutions/Marain.Tenancy.sln
+++ b/Solutions/Marain.Tenancy.sln
@@ -22,6 +22,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Marain.Tenancy.Client", "Ma
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Marain.Tenancy.ClientTenantProvider", "Marain.Tenancy.ClientTenantProvider\Marain.Tenancy.ClientTenantProvider.csproj", "{97382102-88AF-405C-9992-9E743634458A}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Marain.Tenancy.Cli", "Marain.Tenancy.Cli\Marain.Tenancy.Cli.csproj", "{0FFC24C6-C870-4069-82B5-59E2657293F5}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -56,6 +58,10 @@ Global
 		{97382102-88AF-405C-9992-9E743634458A}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{97382102-88AF-405C-9992-9E743634458A}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{97382102-88AF-405C-9992-9E743634458A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0FFC24C6-C870-4069-82B5-59E2657293F5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0FFC24C6-C870-4069-82B5-59E2657293F5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0FFC24C6-C870-4069-82B5-59E2657293F5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0FFC24C6-C870-4069-82B5-59E2657293F5}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Now we have an instance of the tenancy service available (as part of Marain.Instance) we need a way of adding and removing tenants. This is a first step in that direction, giving command line tools for basic CRUD operations.

Includes fix to resolve #73 