### PR TITLE
Fix ClientTenantProvider serialization issues in UpdateTenantAsync

### DIFF
--- a/Solutions/Marain.Tenancy.Specs/Integration/Bindings/TenancyApiBindings.cs
+++ b/Solutions/Marain.Tenancy.Specs/Integration/Bindings/TenancyApiBindings.cs
@@ -6,7 +6,7 @@ namespace Marain.Tenancy.Specs.Integration.Bindings
 {
     using System.Collections.Generic;
     using Corvus.Azure.Storage.Tenancy;
-    using Corvus.SpecFlow.Extensions;
+    using Corvus.Testing.SpecFlow;
     using Microsoft.Extensions.Configuration;
     using Microsoft.Extensions.DependencyInjection;
     using TechTalk.SpecFlow;

--- a/Solutions/Marain.Tenancy.Specs/Integration/Bindings/TenancyClientBindings.cs
+++ b/Solutions/Marain.Tenancy.Specs/Integration/Bindings/TenancyClientBindings.cs
@@ -5,7 +5,7 @@
 namespace Marain.Tenancy.Specs.Integration.Bindings
 {
     using System.Collections.Generic;
-    using Corvus.SpecFlow.Extensions;
+    using Corvus.Testing.SpecFlow;
     using Marain.Tenancy.Client;
     using Microsoft.Extensions.Configuration;
     using Microsoft.Extensions.DependencyInjection;
@@ -39,8 +39,12 @@ namespace Marain.Tenancy.Specs.Integration.Bindings
                         .Build();
                     serviceCollection.AddSingleton(config);
 
+                    serviceCollection.AddJsonSerializerSettings();
+
                     serviceCollection.AddSingleton(sp => sp.GetRequiredService<IConfigurationRoot>().Get<TenancyClientOptions>());
                     serviceCollection.AddTenantProviderServiceClient();
+
+                    serviceCollection.AddMarainTenantManagement();
                 });
         }
     }

--- a/Solutions/Marain.Tenancy.Specs/Integration/Data/OperationsServiceManifest.jsonc
+++ b/Solutions/Marain.Tenancy.Specs/Integration/Data/OperationsServiceManifest.jsonc
@@ -1,0 +1,17 @@
+{
+  "$schema": "./ServiceManifestSchema.json",
+  "contentType": "application/vnd.marain.tenancy.servicemanifests.servicemanifest",
+  "wellKnownTenantGuid": "4f522924-b6e7-48cc-a265-a307407ec858", // This will encode to 3633754ac4c9be44b55bfe791b1780f12429524fe7b6cc48a265a307407ec858
+  "serviceName": "Operations v1",
+  "requiredConfigurationEntries": [
+    {
+      "contentType": "application/vnd.marain.tenancy.servicemanifests.requiredconfigurationentries.azureblobstorage",
+      "type": "azureBlobContainerConfiguration",
+      "key": "operationsStore",
+      "containerDefinition": {
+        "containerName": "operations"
+      },
+      "description": "Stores the status of all current operations"
+    }
+  ]
+}

--- a/Solutions/Marain.Tenancy.Specs/Integration/Features/TenancyClient.feature
+++ b/Solutions/Marain.Tenancy.Specs/Integration/Features/TenancyClient.feature
@@ -36,18 +36,20 @@ Scenario: Create a child tenant
 Scenario: Update a child tenant
 	Given I create a child tenant called "ChildTenant1" for the root tenant
 	When I update the properties of the tenant called "ChildTenant1"
-	| Key       | Value            | Type           |
-	| FirstKey  | 1                | integer        |
-	| SecondKey | This is a string | string         |
-	| ThirdKey  | 1999-01-17       | datetimeoffset |
+	| Key       | Value                           | Type            |
+	| FirstKey  | 1                               | integer         |
+	| SecondKey | This is a string                | string          |
+	| ThirdKey  | 1999-01-17                      | datetimeoffset  |
+	| FourthKey | OperationsServiceManifest.jsonc | ServiceManifest |
 	And I get the tenant id of the tenant called "ChildTenant1" and call it "ChildTenantId"
 	And I get the tenant with the id called "ChildTenantId" and call it "Result"
 	Then the tenant called "ChildTenant1" should have the same ID as the tenant called "Result"
 	And the tenant called "Result" should have the properties
-	| Key       | Value            | Type           |
-	| FirstKey  | 1                | integer        |
-	| SecondKey | This is a string | string         |
-	| ThirdKey  | 1999-01-17       | datetimeoffset |
+	| Key       | Value                           | Type            |
+	| FirstKey  | 1                               | integer         |
+	| SecondKey | This is a string                | string          |
+	| ThirdKey  | 1999-01-17                      | datetimeoffset  |
+	| FourthKey | OperationsServiceManifest.jsonc | ServiceManifest |
 
 Scenario: Add, update, and remove properties of a child tenant
 	Given I create a child tenant called "ChildTenant1" for the root tenant

--- a/Solutions/Marain.Tenancy.Specs/Integration/Features/TenancyClient.feature.cs
+++ b/Solutions/Marain.Tenancy.Specs/Integration/Features/TenancyClient.feature.cs
@@ -305,17 +305,21 @@ this.ScenarioInitialize(scenarioInfo);
                             "ThirdKey",
                             "1999-01-17",
                             "datetimeoffset"});
+                table1.AddRow(new string[] {
+                            "FourthKey",
+                            "OperationsServiceManifest.jsonc",
+                            "ServiceManifest"});
 #line 38
  testRunner.When("I update the properties of the tenant called \"ChildTenant1\"", ((string)(null)), table1, "When ");
 #line hidden
-#line 43
+#line 44
  testRunner.And("I get the tenant id of the tenant called \"ChildTenant1\" and call it \"ChildTenantI" +
                         "d\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
 #line hidden
-#line 44
+#line 45
  testRunner.And("I get the tenant with the id called \"ChildTenantId\" and call it \"Result\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
 #line hidden
-#line 45
+#line 46
  testRunner.Then("the tenant called \"ChildTenant1\" should have the same ID as the tenant called \"Re" +
                         "sult\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
 #line hidden
@@ -335,7 +339,11 @@ this.ScenarioInitialize(scenarioInfo);
                             "ThirdKey",
                             "1999-01-17",
                             "datetimeoffset"});
-#line 46
+                table2.AddRow(new string[] {
+                            "FourthKey",
+                            "OperationsServiceManifest.jsonc",
+                            "ServiceManifest"});
+#line 47
  testRunner.And("the tenant called \"Result\" should have the properties", ((string)(null)), table2, "And ");
 #line hidden
             }
@@ -348,7 +356,7 @@ this.ScenarioInitialize(scenarioInfo);
         {
             string[] tagsOfScenario = ((string[])(null));
             TechTalk.SpecFlow.ScenarioInfo scenarioInfo = new TechTalk.SpecFlow.ScenarioInfo("Add, update, and remove properties of a child tenant", null, ((string[])(null)));
-#line 52
+#line 54
 this.ScenarioInitialize(scenarioInfo);
 #line hidden
             bool isScenarioIgnored = default(bool);
@@ -368,7 +376,7 @@ this.ScenarioInitialize(scenarioInfo);
             else
             {
                 this.ScenarioStart();
-#line 53
+#line 55
  testRunner.Given("I create a child tenant called \"ChildTenant1\" for the root tenant", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Given ");
 #line hidden
                 TechTalk.SpecFlow.Table table3 = new TechTalk.SpecFlow.Table(new string[] {
@@ -387,7 +395,7 @@ this.ScenarioInitialize(scenarioInfo);
                             "ThirdKey",
                             "1999-01-17",
                             "datetimeoffset"});
-#line 54
+#line 56
  testRunner.And("I update the properties of the tenant called \"ChildTenant1\"", ((string)(null)), table3, "And ");
 #line hidden
                 TechTalk.SpecFlow.Table table4 = new TechTalk.SpecFlow.Table(new string[] {
@@ -415,22 +423,22 @@ this.ScenarioInitialize(scenarioInfo);
                             "",
                             "",
                             "remove"});
-#line 59
+#line 61
  testRunner.When("I rename the tenant called \"ChildTenant1\" to \"RenamedChildTenant1\" and update its" +
                         " properties", ((string)(null)), table4, "When ");
 #line hidden
-#line 65
+#line 67
  testRunner.And("I get the tenant id of the tenant called \"ChildTenant1\" and call it \"ChildTenantI" +
                         "d\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
 #line hidden
-#line 66
+#line 68
  testRunner.And("I get the tenant with the id called \"ChildTenantId\" and call it \"Result\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
 #line hidden
-#line 67
+#line 69
  testRunner.Then("the tenant called \"ChildTenant1\" should have the same ID as the tenant called \"Re" +
                         "sult\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
 #line hidden
-#line 68
+#line 70
  testRunner.And("the tenant called \"Result\" should now have the name \"RenamedChildTenant1\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
 #line hidden
                 TechTalk.SpecFlow.Table table5 = new TechTalk.SpecFlow.Table(new string[] {
@@ -453,7 +461,7 @@ this.ScenarioInitialize(scenarioInfo);
                             "FifthKey",
                             "This is a new string",
                             "string"});
-#line 69
+#line 71
  testRunner.And("the tenant called \"Result\" should have the properties", ((string)(null)), table5, "And ");
 #line hidden
             }
@@ -466,7 +474,7 @@ this.ScenarioInitialize(scenarioInfo);
         {
             string[] tagsOfScenario = ((string[])(null));
             TechTalk.SpecFlow.ScenarioInfo scenarioInfo = new TechTalk.SpecFlow.ScenarioInfo("Create a child of a child", null, ((string[])(null)));
-#line 76
+#line 78
 this.ScenarioInitialize(scenarioInfo);
 #line hidden
             bool isScenarioIgnored = default(bool);
@@ -486,21 +494,21 @@ this.ScenarioInitialize(scenarioInfo);
             else
             {
                 this.ScenarioStart();
-#line 77
+#line 79
  testRunner.Given("I create a child tenant called \"ChildTenant1\" for the root tenant", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Given ");
 #line hidden
-#line 78
+#line 80
  testRunner.And("I create a child tenant called \"ChildTenant2\" for the tenant called \"ChildTenant1" +
                         "\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
 #line hidden
-#line 79
+#line 81
  testRunner.When("I get the tenant id of the tenant called \"ChildTenant2\" and call it \"ChildTenantI" +
                         "d\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
 #line hidden
-#line 80
+#line 82
  testRunner.And("I get the tenant with the id called \"ChildTenantId\" and call it \"Result\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
 #line hidden
-#line 81
+#line 83
  testRunner.Then("the tenant called \"ChildTenant2\" should have the same ID as the tenant called \"Re" +
                         "sult\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
 #line hidden
@@ -514,7 +522,7 @@ this.ScenarioInitialize(scenarioInfo);
         {
             string[] tagsOfScenario = ((string[])(null));
             TechTalk.SpecFlow.ScenarioInfo scenarioInfo = new TechTalk.SpecFlow.ScenarioInfo("Get children", null, ((string[])(null)));
-#line 83
+#line 85
 this.ScenarioInitialize(scenarioInfo);
 #line hidden
             bool isScenarioIgnored = default(bool);
@@ -534,30 +542,30 @@ this.ScenarioInitialize(scenarioInfo);
             else
             {
                 this.ScenarioStart();
-#line 84
+#line 86
  testRunner.Given("I create a child tenant called \"ChildTenant1\" for the root tenant", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Given ");
 #line hidden
-#line 85
+#line 87
  testRunner.And("I create a child tenant called \"ChildTenant2\" for the tenant called \"ChildTenant1" +
                         "\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
 #line hidden
-#line 86
+#line 88
  testRunner.And("I create a child tenant called \"ChildTenant3\" for the tenant called \"ChildTenant1" +
                         "\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
 #line hidden
-#line 87
+#line 89
  testRunner.And("I create a child tenant called \"ChildTenant4\" for the tenant called \"ChildTenant1" +
                         "\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
 #line hidden
-#line 88
+#line 90
  testRunner.And("I create a child tenant called \"ChildTenant5\" for the tenant called \"ChildTenant1" +
                         "\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
 #line hidden
-#line 89
+#line 91
  testRunner.When("I get the tenant id of the tenant called \"ChildTenant1\" and call it \"ChildTenantI" +
                         "d\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
 #line hidden
-#line 90
+#line 92
  testRunner.And("I get the children of the tenant with the id called \"ChildTenantId\" with maxItems" +
                         " 20 and call them \"Result\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
 #line hidden
@@ -571,7 +579,7 @@ this.ScenarioInitialize(scenarioInfo);
                             "ChildTenant4"});
                 table6.AddRow(new string[] {
                             "ChildTenant5"});
-#line 91
+#line 93
  testRunner.Then("the ids of the children called \"Result\" should match the ids of the tenants calle" +
                         "d", ((string)(null)), table6, "Then ");
 #line hidden
@@ -585,7 +593,7 @@ this.ScenarioInitialize(scenarioInfo);
         {
             string[] tagsOfScenario = ((string[])(null));
             TechTalk.SpecFlow.ScenarioInfo scenarioInfo = new TechTalk.SpecFlow.ScenarioInfo("Get children when no child tenants exist", null, ((string[])(null)));
-#line 98
+#line 100
 this.ScenarioInitialize(scenarioInfo);
 #line hidden
             bool isScenarioIgnored = default(bool);
@@ -605,18 +613,18 @@ this.ScenarioInitialize(scenarioInfo);
             else
             {
                 this.ScenarioStart();
-#line 99
+#line 101
  testRunner.Given("I create a child tenant called \"ChildTenant1\" for the root tenant", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Given ");
 #line hidden
-#line 100
+#line 102
  testRunner.When("I get the tenant id of the tenant called \"ChildTenant1\" and call it \"ChildTenantI" +
                         "d\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
 #line hidden
-#line 101
+#line 103
  testRunner.And("I get the children of the tenant with the id called \"ChildTenantId\" with maxItems" +
                         " 20 and call them \"Result\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
 #line hidden
-#line 102
+#line 104
  testRunner.Then("there should be no ids in the children called \"Result\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
 #line hidden
             }
@@ -629,7 +637,7 @@ this.ScenarioInitialize(scenarioInfo);
         {
             string[] tagsOfScenario = ((string[])(null));
             TechTalk.SpecFlow.ScenarioInfo scenarioInfo = new TechTalk.SpecFlow.ScenarioInfo("Get children when there is a single child tenant", null, ((string[])(null)));
-#line 104
+#line 106
 this.ScenarioInitialize(scenarioInfo);
 #line hidden
             bool isScenarioIgnored = default(bool);
@@ -649,18 +657,18 @@ this.ScenarioInitialize(scenarioInfo);
             else
             {
                 this.ScenarioStart();
-#line 105
+#line 107
  testRunner.Given("I create a child tenant called \"ChildTenant1\" for the root tenant", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Given ");
 #line hidden
-#line 106
+#line 108
  testRunner.And("I create a child tenant called \"ChildTenant2\" for the tenant called \"ChildTenant1" +
                         "\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
 #line hidden
-#line 107
+#line 109
  testRunner.When("I get the tenant id of the tenant called \"ChildTenant1\" and call it \"ChildTenantI" +
                         "d\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
 #line hidden
-#line 108
+#line 110
  testRunner.And("I get the children of the tenant with the id called \"ChildTenantId\" with maxItems" +
                         " 20 and call them \"Result\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
 #line hidden
@@ -668,7 +676,7 @@ this.ScenarioInitialize(scenarioInfo);
                             "TenantName"});
                 table7.AddRow(new string[] {
                             "ChildTenant2"});
-#line 109
+#line 111
  testRunner.Then("the ids of the children called \"Result\" should match the ids of the tenants calle" +
                         "d", ((string)(null)), table7, "Then ");
 #line hidden
@@ -682,7 +690,7 @@ this.ScenarioInitialize(scenarioInfo);
         {
             string[] tagsOfScenario = ((string[])(null));
             TechTalk.SpecFlow.ScenarioInfo scenarioInfo = new TechTalk.SpecFlow.ScenarioInfo("Get children with continuation token", null, ((string[])(null)));
-#line 113
+#line 115
 this.ScenarioInitialize(scenarioInfo);
 #line hidden
             bool isScenarioIgnored = default(bool);
@@ -702,41 +710,41 @@ this.ScenarioInitialize(scenarioInfo);
             else
             {
                 this.ScenarioStart();
-#line 114
+#line 116
  testRunner.Given("I create a child tenant called \"ChildTenant1\" for the root tenant", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Given ");
 #line hidden
-#line 115
+#line 117
  testRunner.And("I create a child tenant called \"ChildTenant2\" for the tenant called \"ChildTenant1" +
                         "\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
 #line hidden
-#line 116
+#line 118
  testRunner.And("I create a child tenant called \"ChildTenant3\" for the tenant called \"ChildTenant1" +
                         "\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
 #line hidden
-#line 117
+#line 119
  testRunner.And("I create a child tenant called \"ChildTenant4\" for the tenant called \"ChildTenant1" +
                         "\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
 #line hidden
-#line 118
+#line 120
  testRunner.And("I create a child tenant called \"ChildTenant5\" for the tenant called \"ChildTenant1" +
                         "\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
 #line hidden
-#line 119
+#line 121
  testRunner.When("I get the tenant id of the tenant called \"ChildTenant1\" and call it \"ChildTenantI" +
                         "d\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
 #line hidden
-#line 120
+#line 122
  testRunner.And("I get the children of the tenant with the id called \"ChildTenantId\" with maxItems" +
                         " 2 and call them \"Result\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
 #line hidden
-#line 121
+#line 123
  testRunner.And("I get the children of the tenant with the id called \"ChildTenantId\" with maxItems" +
                         " 20 and continuation token \"Result\" and call them \"Result2\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
 #line hidden
-#line 122
+#line 124
  testRunner.Then("there should be 2 tenants in \"Result\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
 #line hidden
-#line 123
+#line 125
  testRunner.And("there should be 2 tenants in \"Result2\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
 #line hidden
                 TechTalk.SpecFlow.Table table8 = new TechTalk.SpecFlow.Table(new string[] {
@@ -749,7 +757,7 @@ this.ScenarioInitialize(scenarioInfo);
                             "ChildTenant3"});
                 table8.AddRow(new string[] {
                             "ChildTenant2"});
-#line 124
+#line 126
  testRunner.And("the ids of the children called \"Result\" and \"Result2\" should each match 2 of the " +
                         "ids of the tenants called", ((string)(null)), table8, "And ");
 #line hidden
@@ -763,7 +771,7 @@ this.ScenarioInitialize(scenarioInfo);
         {
             string[] tagsOfScenario = ((string[])(null));
             TechTalk.SpecFlow.ScenarioInfo scenarioInfo = new TechTalk.SpecFlow.ScenarioInfo("Delete a child", null, ((string[])(null)));
-#line 131
+#line 133
 this.ScenarioInitialize(scenarioInfo);
 #line hidden
             bool isScenarioIgnored = default(bool);
@@ -783,37 +791,37 @@ this.ScenarioInitialize(scenarioInfo);
             else
             {
                 this.ScenarioStart();
-#line 132
+#line 134
  testRunner.Given("I create a child tenant called \"ChildTenant1\" for the root tenant", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Given ");
 #line hidden
-#line 133
+#line 135
  testRunner.And("I create a child tenant called \"ChildTenant2\" for the tenant called \"ChildTenant1" +
                         "\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
 #line hidden
-#line 134
+#line 136
  testRunner.And("I create a child tenant called \"ChildTenant3\" for the tenant called \"ChildTenant1" +
                         "\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
 #line hidden
-#line 135
+#line 137
  testRunner.And("I create a child tenant called \"ChildTenant4\" for the tenant called \"ChildTenant1" +
                         "\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
 #line hidden
-#line 136
+#line 138
  testRunner.And("I create a child tenant called \"ChildTenant5\" for the tenant called \"ChildTenant1" +
                         "\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
 #line hidden
-#line 137
+#line 139
  testRunner.When("I get the tenant id of the tenant called \"ChildTenant1\" and call it \"ChildTenantI" +
                         "d\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
 #line hidden
-#line 138
+#line 140
  testRunner.And("I get the tenant id of the tenant called \"ChildTenant3\" and call it \"DeletedChild" +
                         "TenantId\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
 #line hidden
-#line 139
+#line 141
  testRunner.And("I delete the tenant with the id called \"DeletedChildTenantId\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
 #line hidden
-#line 140
+#line 142
  testRunner.And("I get the children of the tenant with the id called \"ChildTenantId\" with maxItems" +
                         " 20 and call them \"Result\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
 #line hidden
@@ -825,7 +833,7 @@ this.ScenarioInitialize(scenarioInfo);
                             "ChildTenant4"});
                 table9.AddRow(new string[] {
                             "ChildTenant5"});
-#line 141
+#line 143
  testRunner.Then("the ids of the children called \"Result\" should match the ids of the tenants calle" +
                         "d", ((string)(null)), table9, "Then ");
 #line hidden
@@ -839,7 +847,7 @@ this.ScenarioInitialize(scenarioInfo);
         {
             string[] tagsOfScenario = ((string[])(null));
             TechTalk.SpecFlow.ScenarioInfo scenarioInfo = new TechTalk.SpecFlow.ScenarioInfo("Root tenant has empty properties", null, ((string[])(null)));
-#line 147
+#line 149
 this.ScenarioInitialize(scenarioInfo);
 #line hidden
             bool isScenarioIgnored = default(bool);
@@ -859,10 +867,10 @@ this.ScenarioInitialize(scenarioInfo);
             else
             {
                 this.ScenarioStart();
-#line 148
+#line 150
  testRunner.When("I get the tenant with id \"f26450ab1668784bb327951c8b08f347\" and call it \"Root\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
 #line hidden
-#line 149
+#line 151
  testRunner.Then("the tenant called \"Root\" should have no properties", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
 #line hidden
             }
@@ -875,7 +883,7 @@ this.ScenarioInitialize(scenarioInfo);
         {
             string[] tagsOfScenario = ((string[])(null));
             TechTalk.SpecFlow.ScenarioInfo scenarioInfo = new TechTalk.SpecFlow.ScenarioInfo("Updates to root tenant are prohibited", null, ((string[])(null)));
-#line 151
+#line 153
 this.ScenarioInitialize(scenarioInfo);
 #line hidden
             bool isScenarioIgnored = default(bool);
@@ -895,11 +903,11 @@ this.ScenarioInitialize(scenarioInfo);
             else
             {
                 this.ScenarioStart();
-#line 152
+#line 154
  testRunner.When("I try to update the properties of the tenant with id \"f26450ab1668784bb327951c8b0" +
                         "8f347\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
 #line hidden
-#line 153
+#line 155
  testRunner.Then("it should throw a NotSupportedException", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
 #line hidden
             }

--- a/Solutions/Marain.Tenancy.Specs/Marain.Tenancy.Specs.csproj
+++ b/Solutions/Marain.Tenancy.Specs/Marain.Tenancy.Specs.csproj
@@ -17,7 +17,17 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Corvus.SpecFlow.Extensions" Version="0.7.0-49-system-management-version.6" />
+    <None Remove="Integration\Data\OperationsServiceManifest.jsonc" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <EmbeddedResource Include="Integration\Data\OperationsServiceManifest.jsonc" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Corvus.Testing.AzureFunctions.SpecFlow" Version="0.7.0-preview.40" />
+    <PackageReference Include="Corvus.Testing.SpecFlow" Version="0.7.0-preview.40" />
+    <PackageReference Include="Marain.TenantManagement.Abstractions" Version="0.1.0-preview.16" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="2.2.4" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.2.0" />

--- a/Solutions/Marain.Tenancy.Specs/specflow.json
+++ b/Solutions/Marain.Tenancy.Specs/specflow.json
@@ -1,5 +1,6 @@
 {
   "stepAssemblies": [
-    { "assembly": "Corvus.SpecFlow.Extensions" }
+    { "assembly": "Corvus.Testing.SpecFlow" },
+    { "assembly": "Corvus.Testing.AzureFunctions.SpecFlow" }
   ]
 }


### PR DESCRIPTION
A bug in Marain.TenantManagement where the service manifests attached to new service tenants were not being persisted correctly got traced back to the way in which tenants are now being updated. When we want to add properties to a tenant we do so using the `UpdateTenantAsync` method of the `ClientTenantStore` which prepares a list of `UpdateTenantJsonPatchEntry` objects to PATCH to the tenancy service. 

The autogenerated tenancy client internally uses `SafeJsonConvert` (https://docs.microsoft.com/en-us/dotnet/api/microsoft.rest.serialization.safejsonconvert?view=azure-dotnet) to serialize these, and it turns out that as well as this using hard coded serialization settings, this does not serialize read-only properties, which explained why our ServiceManifest was being mangled.

To get round this, I've updated `ClientTenantStore.UpdateTenantAsync` to convert values in the `propertiesToSetOrAdd` collection to `JToken` when creating the `UpdateTenantJsonPatchEntry`. This allows us to take control of the serialization using our own serialization settings.

I've also added to the `Update a child tenant` spec to explicitly test adding a `ServiceManifest` property, since this is a critical part of the way we use tenants in Marain services.