### PR TITLE
Ensure AppInsights logging respects the log level set in host.json

### DIFF
--- a/Solutions/Marain.Tenancy.Host.Functions/Marain.Tenancy.Host.Functions.csproj
+++ b/Solutions/Marain.Tenancy.Host.Functions/Marain.Tenancy.Host.Functions.csproj
@@ -11,6 +11,7 @@
   </PropertyGroup>
   
   <ItemGroup>
+    <PackageReference Include="Corvus.Monitoring.ApplicationInsights" Version="1.0.0" />
     <PackageReference Include="Corvus.Tenancy.Storage.Azure.Blob" Version="1.0.0" />
     <PackageReference Include="Endjin.RecommendedPractices" Version="1.2.0">
       <PrivateAssets>all</PrivateAssets>

--- a/Solutions/Marain.Tenancy.Host.Functions/Marain/Tenancy/Functions/Startup.cs
+++ b/Solutions/Marain.Tenancy.Host.Functions/Marain/Tenancy/Functions/Startup.cs
@@ -27,20 +27,9 @@ namespace Marain.Tenancy.ControlHost
         {
             IServiceCollection services = builder.Services;
 
-            services.AddLogging();
+            services.AddApplicationInsightsInstrumentationTelemetry();
 
-            // TODO: putting TelemetryClient in manually to work around regression
-            // introduced in Functions v3 - see:
-            // https://github.com/Azure/azure-functions-host/issues/5353
-            // Apparently this has been fixed:
-            // https://github.com/Azure/azure-functions-host/pull/5551
-            // but at time of writing this code (11th Feb 2020) that fix was not
-            // yet available for use.
-            string key = Environment.GetEnvironmentVariable("APPINSIGHTS_INSTRUMENTATIONKEY");
-            var tc = new TelemetryClient(string.IsNullOrWhiteSpace(key)
-                ? new TelemetryConfiguration()
-                : new TelemetryConfiguration(key));
-            services.AddSingleton(tc);
+            services.AddLogging();
 
             services.AddSingleton(sp => sp.GetRequiredService<IConfiguration>().GetSection("TenantCloudBlobContainerFactoryOptions").Get<TenantCloudBlobContainerFactoryOptions>());
 

--- a/Solutions/Marain.Tenancy.Host.Functions/host.json
+++ b/Solutions/Marain.Tenancy.Host.Functions/host.json
@@ -7,7 +7,9 @@
   },
   "logging": {
     "logLevel": {
-      "default": "Warning"
+      "default": "Warning",
+      "Host.Results": "Information",
+      "Host.Aggregator": "Information"
     }
   }
 }


### PR DESCRIPTION
A workaround for a regression introduced in v3 of the Azure functions host is now preventing AppInsights logging from using the log levels set in host.json. This PR removes that code and replaces it with Corvus Monitoring and updating host.json configuration to ensure that we still log requests and metrics (which are logged as Information level).