### PR TITLE
Add retry logic to tenancy initialisation during deployment

### DIFF
--- a/Solutions/Marain.Tenancy.Deployment/Marain-PostDeploy.ps1
+++ b/Solutions/Marain.Tenancy.Deployment/Marain-PostDeploy.ps1
@@ -25,10 +25,15 @@ Function MarainDeployment([MarainServiceDeploymentContext] $ServiceDeploymentCon
     # Ensure the tenancy instance is initialised
     try {
         Write-Host "Initialising marain tenancy instance..."
-        $cliOutput = & $ServiceDeploymentContext.InstanceContext.MarainCliPath init
-        if ($LASTEXITCODE -ne 0) {
-            Write-Error "Error whilst trying to initialise the marain tenancy instance: ExitCode=$LASTEXITCODE`n$cliOutput"
+        $scriptBlock = {  
+            $cliOutput = & $ServiceDeploymentContext.InstanceContext.MarainCliPath init
+            if ($LASTEXITCODE -ne 0) {
+                Write-Error "Error whilst trying to initialise the marain tenancy instance: ExitCode=$LASTEXITCODE`n$cliOutput"
+            }
         }
+        Invoke-CommandWithRetry -Command $scriptBlock `
+                                -RetryCount 5 `
+                                -RetryDelay 30
     }
     catch {
         throw $_

--- a/Solutions/Marain.Tenancy.Deployment/Marain-PreDeploy.ps1
+++ b/Solutions/Marain.Tenancy.Deployment/Marain-PreDeploy.ps1
@@ -73,5 +73,5 @@ Function MarainDeployment([MarainServiceDeploymentContext] $ServiceDeploymentCon
         Write-Error "The default tenancy administrator credential was not available in the keyvault - access to AAD is required to resolve this issue"
     }
 
-    $ServiceDeploymentContext.InstanceContext.TenantAdminSecret = ($tenantAdminSecret).SecretValueText
+    $ServiceDeploymentContext.InstanceContext.TenantAdminSecret = ConvertFrom-SecureString $tenantAdminSecret.SecretValue -AsPlainText
 }

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -34,7 +34,7 @@ jobs:
         inputs:
           command: custom
           verbose: false
-          customCommand: 'install -g azure-functions-core-tools@3 --unsafe-perm true'
+          customCommand: 'install -g azure-functions-core-tools@3.0.2630 --unsafe-perm true'
 
     # We want to include the deployment project in the assets. Currently this is experimental,
     # and once we're done, probably some of this is going to move into the common templates.


### PR DESCRIPTION
Workaround for a timing issue that can arise whereby the tenancy service is not ready to receive the requests made by the `marain-cli` immediately following the AppService deployment.

Also pins the version of the `azure-functions-core` package.