### PR TITLE
Update dependencies

### DIFF
--- a/Solutions/Marain.Tenancy.ClientTenantProvider/Marain.Tenancy.ClientTenantProvider.csproj
+++ b/Solutions/Marain.Tenancy.ClientTenantProvider/Marain.Tenancy.ClientTenantProvider.csproj
@@ -17,7 +17,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Corvus.Tenancy.Abstractions" Version="2.0.7" />
+    <PackageReference Include="Corvus.Tenancy.Abstractions" Version="2.0.10" />
     <PackageReference Include="Endjin.RecommendedPractices" Version="1.2.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Solutions/Marain.Tenancy.Hosting.AspNetCore/Marain.Tenancy.Hosting.AspNetCore.csproj
+++ b/Solutions/Marain.Tenancy.Hosting.AspNetCore/Marain.Tenancy.Hosting.AspNetCore.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Corvus.Tenancy.Storage.Azure.Blob" Version="2.0.7" />
+    <PackageReference Include="Corvus.Tenancy.Storage.Azure.Blob" Version="2.0.10" />
     <PackageReference Include="Endjin.RecommendedPractices" Version="1.2.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Solutions/Marain.Tenancy.OpenApi.Service/Marain.Tenancy.OpenApi.Service.csproj
+++ b/Solutions/Marain.Tenancy.OpenApi.Service/Marain.Tenancy.OpenApi.Service.csproj
@@ -25,17 +25,17 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Corvus.Azure.Storage.Tenancy" Version="2.0.7" />
+    <PackageReference Include="Corvus.Azure.Storage.Tenancy" Version="2.0.10" />
     <PackageReference Include="Endjin.RecommendedPractices" Version="1.2.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Menes.Abstractions" Version="2.0.1" />
-    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.17.0" />
+    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.18.0" />
     <PackageReference Include="Microsoft.AspNetCore.JsonPatch" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="[3.1.*,)" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="[3.1.*,)" />
-    <PackageReference Include="Corvus.Tenancy.Abstractions" Version="2.0.7" />
+    <PackageReference Include="Corvus.Tenancy.Abstractions" Version="2.0.10" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Primarily to pull in latest Corvus.Tenancy changes to prevent the tenancy service getting stuck in a "faulted"-type state if connection to an underlying tenant store fails.