### PR TITLE
Add Endjin.RecommendedPractices to the Tenancy client

### DIFF
--- a/Solutions/Marain.Tenancy.Client/Marain.Tenancy.Client.csproj
+++ b/Solutions/Marain.Tenancy.Client/Marain.Tenancy.Client.csproj
@@ -1,29 +1,21 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
-  <!--
-  Not using normal Endjin.RecommendedPractices import, because this contains AutoRest-generated code, which makes
-  the analyzers we normally bring in unhappy.
-  -->
+  <Import Project="$(EndjinProjectPropsPath)" Condition="$(EndjinProjectPropsPath) != ''" />
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <RootNamespace />
-    <OutputPath>bin\$(Configuration)\</OutputPath>
-    <DocumentationFile>$(OutputPath)$(TargetFramework.ToLowerInvariant())\$(AssemblyName).xml</DocumentationFile>
   </PropertyGroup>
 
   <PropertyGroup>
     <NoWarn>1701;1702;1591;1573</NoWarn>
     <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
-    <TreatSpecificWarningsAsErrors />
-    <WarningsAsErrors />
-  </PropertyGroup>
-
-  <PropertyGroup>
-    <DebugType>Full</DebugType>
+    <EndjinDisableCodeAnalysis>true</EndjinDisableCodeAnalysis>
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Endjin.RecommendedPractices" Version="1.2.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="CacheCow.Client" Version="2.9.0" />
     <PackageReference Include="Corvus.ContentHandling.Json" Version="2.0.11" />
     <PackageReference Include="Corvus.Extensions" Version="1.1.4" />

--- a/Solutions/Marain.Tenancy.Client/Marain.Tenancy.Client.csproj
+++ b/Solutions/Marain.Tenancy.Client/Marain.Tenancy.Client.csproj
@@ -11,6 +11,16 @@
     <EndjinDisableCodeAnalysis>true</EndjinDisableCodeAnalysis>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <PackageLicenseExpression>AGPL-3.0-or-later</PackageLicenseExpression>
+    <PackageDescription>
+    </PackageDescription>
+    <PackageTags>
+    </PackageTags>
+    <PackageReleaseNotes>
+    </PackageReleaseNotes>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="Endjin.RecommendedPractices" Version="1.2.0">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
At the moment it's not possible to use SourceLink with Marain.Tenancy.Client. This is normally set up by Endjin.RecommendedPractices.NuGet. However, we didn't add Endjin.RecommendedPractices.NuGet to this project as the resulting analyzers picked up a lot of issues with the Autorest-generated code. However, it's possible to disable the analyzers with an additional property in the csproj, so adding Endjin.RecommendedPractices.NuGet will give us SourceLink and bring other project settings in line with Endjin standards.