### PR TITLE
Updates to require recent version of Az PowerShell AAD cmdlets

### DIFF
--- a/Solutions/Marain.Tenancy.Deployment/Marain-PreDeploy.ps1
+++ b/Solutions/Marain.Tenancy.Deployment/Marain-PreDeploy.ps1
@@ -57,7 +57,8 @@ Function MarainDeployment([MarainServiceDeploymentContext] $ServiceDeploymentCon
 
             $ServiceDeploymentContext.InstanceContext.TenantAdminAppId = $newSp.AppId
             $ServiceDeploymentContext.InstanceContext.TenantAdminObjectId = $newSp.Id
-            Set-AzKeyVaultSecret -VaultName $keyVaultName -Name $tenantAdminSecretName -SecretValue $newSp.PasswordCredentials[0].SecretText | Out-Null
+            $spSecret = ConvertTo-SecureString $newSp.PasswordCredentials[0].SecretText -AsPlainText
+            Set-AzKeyVaultSecret -VaultName $keyVaultName -Name $tenantAdminSecretName -SecretValue $spSecret | Out-Null
         }
     }
     else {

--- a/Solutions/Marain.Tenancy.Deployment/Marain-PreDeploy.ps1
+++ b/Solutions/Marain.Tenancy.Deployment/Marain-PreDeploy.ps1
@@ -9,6 +9,8 @@ use it directly.)
 
 #>
 
+#Requires -Modules @{ ModuleName = "Az.Resources"; ModuleVersion = "5.4.0" }
+
 # Marain.Instance expects us to define just this one function.
 Function MarainDeployment([MarainServiceDeploymentContext] $ServiceDeploymentContext) {
 
@@ -35,11 +37,6 @@ Function MarainDeployment([MarainServiceDeploymentContext] $ServiceDeploymentCon
     $tenantAdminSecretName = "DefaultTenantAdminPassword"
     $defaultTenantAdminSpName = '{0}{1}tenantadmin' -f $ServiceDeploymentContext.InstanceContext.Prefix, $ServiceDeploymentContext.InstanceContext.EnvironmentSuffix
 
-    # Handle the breaking changes for versions of Azure PowerShell that use Microsoft Graph for its AAD interactions
-    # ref: https://docs.microsoft.com/en-us/powershell/azure/azps-msgraph-migration-changes
-    $appIdPropertyName = (Get-Module Az.Resources).Version.Major -ge 5 ? "AppId" : "ApplicationId"
-    $objectIdPropertyName = (Get-Module Az.Resources).Version.Major -ge 5 ? "Id" : "ObjectId"
-
     # Ensure a default tenancy administrator principal is setup/available
     if ($ServiceDeploymentContext.InstanceContext.AadAppIds.ContainsKey($defaultTenantAdminSpName)) {
         # Use AadAppId provided on the command-line
@@ -49,24 +46,18 @@ Function MarainDeployment([MarainServiceDeploymentContext] $ServiceDeploymentCon
         # look-up from AAD directly, if we have access
         $existingSp = Get-AzADServicePrincipal -DisplayName $defaultTenantAdminSpName        
         if ($existingSp) {
-            $ServiceDeploymentContext.InstanceContext.TenantAdminAppId = $existingSp.$appIdPropertyName
+            $ServiceDeploymentContext.InstanceContext.TenantAdminAppId = $existingSp.AppId
         }
         else {
             Write-Host "Creating default tenancy administrator service principal"
             $newSpParams = @{
                 DisplayName = $defaultTenantAdminSpName
             }
-            if ((Get-Module Az.Resources).Version.Major -lt 5) {
-                # Earlier versions of Azure PowerShell grant the 'Contributor' role by default, however, current versions
-                # do not and the 'SkipAssignment' switch has been removed (i.e. it is no longer valid)
-                # ref: https://docs.microsoft.com/en-us/powershell/azure/azps-msgraph-migration-changes
-                $newSpParams += @{ SkipAssignment = $true }
-            }
             $newSp = New-AzADServicePrincipal @newSpParams  
 
-            $ServiceDeploymentContext.InstanceContext.TenantAdminAppId = $newSp.$appIdPropertyName
-            $ServiceDeploymentContext.InstanceContext.TenantAdminObjectId = $newSp.$objectIdPropertyName
-            Set-AzKeyVaultSecret -VaultName $keyVaultName -Name $tenantAdminSecretName -SecretValue $newSp.SecretValue | Out-Null
+            $ServiceDeploymentContext.InstanceContext.TenantAdminAppId = $newSp.AppId
+            $ServiceDeploymentContext.InstanceContext.TenantAdminObjectId = $newSp.Id
+            Set-AzKeyVaultSecret -VaultName $keyVaultName -Name $tenantAdminSecretName -SecretValue $newSp.PasswordCredentials[0].SecretText | Out-Null
         }
     }
     else {


### PR DESCRIPTION
* Fixes issue with changes to how new service principal details are returned
* Removes handling for earlier versions of Azure PowerShell modules (i.e. pre MS Graph migration)