### PR TITLE
Register IServiceIdentityAzureTokenCredentialSource in DI

### DIFF
--- a/Solutions/Marain.Tenancy.Host.Functions/Marain/Tenancy/Functions/Startup.cs
+++ b/Solutions/Marain.Tenancy.Host.Functions/Marain/Tenancy/Functions/Startup.cs
@@ -8,6 +8,9 @@ namespace Marain.Tenancy.ControlHost
 {
     using System;
 
+    using Azure.Identity;
+
+    using Corvus.Identity.ClientAuthentication.Azure;
     using Corvus.Storage.Azure.BlobStorage;
 
     using Menes;
@@ -36,6 +39,14 @@ namespace Marain.Tenancy.ControlHost
                 .Get<BlobContainerConfiguration>();
             services.AddTenantStoreOnAzureBlobStorage(rootStorageConfiguration);
             services.AddTenancyApiWithOpenApiActionResultHosting(this.ConfigureOpenApiHost);
+            if (rootStorageConfiguration?.AccessKeyInKeyVault?.VaultClientIdentity is ClientIdentityConfiguration idconfig)
+            {
+                services.AddServiceIdentityAzureTokenCredentialSourceFromClientIdentityConfiguration(idconfig);
+            }
+            else
+            {
+                services.AddServiceIdentityAzureTokenCredentialSourceFromAzureCoreTokenCredential(new DefaultAzureCredential());
+            }
         }
 
         private void ConfigureOpenApiHost(IOpenApiHostConfiguration config)


### PR DESCRIPTION
Resolves #484 

This is required for certain V2 backwards compatibility scenarios